### PR TITLE
fix lua Makefile.am

### DIFF
--- a/src/modules/lua/Makefile.am
+++ b/src/modules/lua/Makefile.am
@@ -7,7 +7,7 @@ INCLUDES= -I$(top_srcdir)/include -I$(top_srcdir)/src -I$(LUA_INCLUDES)
 
 mod_lua_la_METASOURCES= AUTO
 
-mod_lua_la_SOURCES=lsluascript.cpp lsluaengine.cpp edluastream.cpp lsluaapi.cpp \
-    lsluasession.cpp lsluaheader.cpp lsluashared.cpp modlua.cpp
+mod_lua_la_SOURCES=lsluaengine.cpp edluastream.cpp lsluaapi.cpp \
+    lsluasession.cpp lsluaheader.cpp lsluashared.cpp lsluaregex.cpp modlua.cpp
 
 #noinst_HEADERS = 


### PR DESCRIPTION
I saw the lua src changes in the new cmake for lua, and brought it back to
the old automake file.  You need to run autoreconf also then.  I've got a newer
automake so I'll leave it to you.

Just met two of your guys at WHD.global btw. Great talking, thanks for a great product.