### PR TITLE
Add support for PATCH HTTP method

### DIFF
--- a/src/http/httpglobals.cpp
+++ b/src/http/httpglobals.cpp
@@ -128,6 +128,7 @@ const char *HttpMethod::s_psMethod[HttpMethod::HTTP_METHOD_END] =
     "HEAD",
     "POST",
     "PUT",
+    "PATCH",
     "DELETE",
     "TRACE",
     "CONNECT",
@@ -157,7 +158,7 @@ const char *HttpMethod::s_psMethod[HttpMethod::HTTP_METHOD_END] =
 };
 int HttpMethod::s_iMethodLen[HttpMethod::HTTP_METHOD_END] =
 {
-    7, 7, 3, 4, 4, 3, 6, 5, 7, 4,
+    7, 7, 3, 4, 4, 3, 5, 6, 5, 7, 4,
     8, 9, 5, 4, 4, 6, 15, 6, 7, 8, 10, 7, 11, 5, 5, 16, 10, 4, 6, 5, 7
 };
 

--- a/src/http/httpmethod.cpp
+++ b/src/http/httpmethod.cpp
@@ -39,7 +39,10 @@ http_method_t HttpMethod::parse2(const char *pMethod)
         switch (*(pMethod + 2) & ~0x20)
         {
         case 'T':
-            method = HTTP_PUT;
+            if ('A' == (*(pMethod + 1) & ~0x20))
+                method = HTTP_PATCH;
+            else
+                method = HTTP_PUT;
             break;
         case 'R':
             method = HTTP_PURGE;

--- a/src/http/httpmethod.h
+++ b/src/http/httpmethod.h
@@ -57,7 +57,8 @@ public:
         DAV_SEARCH,
         HTTP_PURGE,
         HTTP_REFRESH,
-        HTTP_METHOD_END
+        HTTP_METHOD_END,
+        HTTP_PATCH
     };
 
     static http_method_t parse2(const char *pMethod);

--- a/src/http/httpmethod.h
+++ b/src/http/httpmethod.h
@@ -32,6 +32,7 @@ public:
         HTTP_HEAD,
         HTTP_POST,
         HTTP_PUT ,
+        HTTP_PATCH,
         HTTP_DELETE,
         HTTP_TRACE,
         HTTP_CONNECT,
@@ -57,8 +58,7 @@ public:
         DAV_SEARCH,
         HTTP_PURGE,
         HTTP_REFRESH,
-        HTTP_METHOD_END,
-        HTTP_PATCH
+        HTTP_METHOD_END
     };
 
     static http_method_t parse2(const char *pMethod);

--- a/src/modules/cache/cache.cpp
+++ b/src/modules/cache/cache.cpp
@@ -75,6 +75,7 @@ enum HTTP_METHOD
     HTTP_HEAD,
     HTTP_POST,
     HTTP_PUT ,
+    HTTP_PATCH,
     HTTP_DELETE,
     HTTP_TRACE,
     HTTP_CONNECT,
@@ -100,8 +101,7 @@ enum HTTP_METHOD
     DAV_SEARCH,
     HTTP_PURGE,
     HTTP_REFRESH,
-    HTTP_METHOD_END,
-    HTTP_PATCH
+    HTTP_METHOD_END
 };
 
 typedef struct _MyMData

--- a/src/modules/cache/cache.cpp
+++ b/src/modules/cache/cache.cpp
@@ -101,6 +101,7 @@ enum HTTP_METHOD
     HTTP_PURGE,
     HTTP_REFRESH,
     HTTP_METHOD_END,
+    HTTP_PATCH
 };
 
 typedef struct _MyMData


### PR DESCRIPTION
This will add support for PATCH HTTP method. This method usually uses in RESTful services. I have tested it in my environment (it works OK). Please review this patch.