### PR TITLE
Replace PHP short tags with recommended ones and fix some spaces

### DIFF
--- a/dist/add-ons/snmp_monitoring/class.litespeed_snmp_bridge.php
+++ b/dist/add-ons/snmp_monitoring/class.litespeed_snmp_bridge.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*----------------------------------------
 LiteSpeed_Stats to SNMP bridge. Relay stats to SNMPD.

--- a/dist/add-ons/snmp_monitoring/class.litespeed_stats.php
+++ b/dist/add-ons/snmp_monitoring/class.litespeed_stats.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*----------------------------------------
 LiteSpeed_Stats class and subclasses. Parse Real-Time data for LiteSpeed Products

--- a/dist/add-ons/snmp_monitoring/sample.php
+++ b/dist/add-ons/snmp_monitoring/sample.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /*--------------------------------
 assuming  following entry in /etc/snmp/snmpd.conf
@@ -25,7 +25,6 @@ if(array_key_exists(1,$_SERVER["argv"]) && array_key_exists(2,$_SERVER["argv"]))
 
 	$bridge = new litespeed_snmp_bridge($processes, $report_path, $cache_time, $cache_file);
 	$bridge->process($type, $oid);
-	
 }
 
 ?>

--- a/dist/admin/html.open/login.php
+++ b/dist/admin/html.open/login.php
@@ -44,7 +44,7 @@ $(document).ready(function() {
 							<form action="login.php"  id="login" method="post" class="smart-form client-form" novalidate="novalidate">
                                                             <header><div class="text-center"><object type="image/svg+xml" data="/res/img/product_logo.svg" width="80%">Your browser doesn't support SVG</object></div></header>
 								<fieldset>
-								<?
+								<?php
 if ($msg != '') {
 	echo "<section><div class=\"note\">$msg</div></section>";
 }


### PR DESCRIPTION
This is a minor patch that replaces PHP short tags used in some files. Change has been made because PHP by default doesn't have short tags enabled:
http://php.net/manual/en/ini.core.php#ini.short-open-tag
and they aren't much recommended to use anymore. Thanks for considering merging this patch.