### PR TITLE
Add string.h to pcutil

### DIFF
--- a/src/util/pcutil.cpp
+++ b/src/util/pcutil.cpp
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #ifdef __linux
 #include <sched.h>
@@ -129,4 +130,3 @@ void PCUtil::setCpuAffinityAll()
         getNumProcessors();
     setCpuAffinity(&s_maskAll);
 }
-


### PR DESCRIPTION
On some systems `string.h` include is required otherwise compiling exits with error `memset was not declared in this scope`. For example, when compiling OpenLiteSpeed on Alpine Linux (for using it with Docker) the following error occurs:

```
In file included from ./util/pcutil.h:22:0,
                 from util/pcutil.cpp:18:
util/pcutil.cpp: In static member function 'static void PCUtil::getAffinityMask(int, int, int, cpu_set_t*)':
util/pcutil.cpp:100:5: error: 'memset' was not declared in this scope
     CPU_ZERO(mask);
     ^
make[3]: *** [Makefile:1819: pcutil.o] Error 1
make[3]: *** Waiting for unfinished jobs....
```

Inspiration for this patch has been found in the [Alpine packages repository](https://git.alpinelinux.org/cgit/aports/tree/testing/litespeed?h=master).

There are some more fixes coming up in the near future... Thank you for taking a look and/or considering merging it in the main repository for some future release.