### PR TITLE
Convert PHP 4/5 style class constructor of jCryption to __construct

### DIFF
--- a/dist/admin/html.open/lib/jCryption.php
+++ b/dist/admin/html.open/lib/jCryption.php
@@ -32,7 +32,7 @@
 		*
 		* @access public
 		*/
-		function jCryption($e = "\x01\x00\x01") {
+		public function __construct($e = "\x01\x00\x01") {
 			$this->_e = $e;
 		}
 


### PR DESCRIPTION
Hello, 

this patch converts the constructor in the jCryption class because when using PHP 7 it raises a E_DEPRECATED when used in PHP CLI. It doesn't change existing behavior.

Thank you for considering merging it.