### PR TITLE
Fix coding style

### DIFF
--- a/configure
+++ b/configure
@@ -20715,5 +20715,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
-

--- a/include/lsr/ls_lock.h
+++ b/include/lsr/ls_lock.h
@@ -478,7 +478,7 @@ ls_inline int ls_atomic_spin_unlock(ls_atom_spinlock_t *p)
  * @param[in] p - A pointer to the lock.
  * @return 1 - locked, 0 - not locked.
  *
- * @see ls_atomic_spin_setup, ls_atomic_spin_lock, ls_atomic_spin_trylock 
+ * @see ls_atomic_spin_setup, ls_atomic_spin_lock, ls_atomic_spin_trylock
  *      ls_atomic_spin_unlock
  */
 ls_inline int ls_atomic_spin_locked(ls_atom_spinlock_t *p)
@@ -511,7 +511,7 @@ ls_inline int ls_atomic_spin_pidunlock(ls_atom_spinlock_t *p)
  * @param[in] p - A pointer to the lock.
  * @return 1 - locked, 0 - not locked.
  *
- * @see ls_atomic_spin_setup, ls_atomic_spin_lock, ls_atomic_spin_trylock 
+ * @see ls_atomic_spin_setup, ls_atomic_spin_lock, ls_atomic_spin_trylock
  *      ls_atomic_spin_unlock
  */
 ls_inline int ls_atomic_pidlocked(ls_atom_spinlock_t *p)
@@ -545,4 +545,3 @@ int ls_pspinlock_setup(ls_pspinlock_t *p);
 #endif
 
 #endif //LS_LOCK_H
-

--- a/src/lsr/ls_lock.c
+++ b/src/lsr/ls_lock.c
@@ -123,4 +123,3 @@ int ls_pspinlock_setup(ls_pspinlock_t   *p)
     }
     return LS_FAIL;
 }
-

--- a/src/thread/pthreadmutex.cpp
+++ b/src/thread/pthreadmutex.cpp
@@ -31,4 +31,3 @@ pthread_mutex_t PThreadMutex::s_proto =
 pthread_mutex_t PThreadMutex::s_proto = PTHREAD_MUTEX_INITIALIZER;
 
 #endif
-

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -166,5 +166,3 @@ public:
 
 
 #endif //THREAD_H
-
-


### PR DESCRIPTION
This is a minor patch that syncs some coding style. It doesn't add new functionality or changes anything, but it is slightly useful for simpler creating of patches in editors that automatically "fix" trailing spaces and ending lines.

Thank you for considering merging it.