### PR TITLE
Fix coding style and convert class constructors to __construct

### DIFF
--- a/dist/add-ons/snmp_monitoring/class.litespeed_snmp_bridge.php
+++ b/dist/add-ons/snmp_monitoring/class.litespeed_snmp_bridge.php
@@ -22,7 +22,7 @@ Version: 1.0 @ 08/23/2006
 Contact: bug@litespeedtech.com
 Url: http://www.litespeedtech.com
 
-Requirement: 
+Requirement:
 
 1)LiteSpeed Web Server version >= 2.1.18
 2)PHP 5+
@@ -31,239 +31,220 @@ Requirement:
 
 require_once("class.litespeed_stats.php");
 
+class litespeed_snmp_bridge
+{
+    public $processes = 1;
+    public $report_path = "/tmp/lshttpd/";
+    public $cache_time = 0;
+    public $cache_file = null;
+    public $stats = null;
 
-class litespeed_snmp_bridge {
-	public $processes = 1;
-	public $report_path = "/tmp/lshttpd/";
-	public $cache_time = 0;
-	public $cache_file = null;
+    public function __construct($processes = 1, $report_path = "/tmp/lshttpd/", $cache_time = 0, $cache_file = null)
+    {
+        $this->processes = (int) $processes;
+        $this->report_path = trim($report_path);
 
-	public $stats = null;
+        //prepare parser
+        if($this->cache_time > 0 && strlen($this->cache_file) > 0) {
+            if(file_exists($this->cache_file) && time() - filemtime($this->cache_file) <= $this->cache_time) {
+                $unserial = unserialize(file_get_contents($this->cache_file));
 
-	public function litespeed_snmp_bridge($processes = 1, $report_path = "/tmp/lshttpd/", $cache_time = 0, $cache_file = null) {
-		$this->processes = (int) $processes;
-		$this->report_path = trim($report_path);
+                if(is_a($unserial,"litespeed_stats")) {
+                    $this->stats = $unserial;
+                } else {
+                    $this->stats = new litespeed_stats($this->processes,$this->report_path);
+                    $this->stats->parse();
+                    $this->save_cache($this->cache_file, $this->stats);
+                }
+            } else {
+                $this->stats = new litespeed_stats($this->processes,$this->report_path);
+                $this->stats->parse();
+                $this->save_cache($this->cache_file, $this->stats);
+            }
+        } else {
+            $this->stats = new litespeed_stats($this->processes,$this->report_path);
+            $this->stats->parse();
+        }
+    }
 
-		//prepare parser
-		if($this->cache_time > 0 && strlen($this->cache_file) > 0) {
-			if(file_exists($this->cache_file) && time() - filemtime($this->cache_file) <= $this->cache_time) {
-				$unserial = unserialize(file_get_contents($this->cache_file));
+    //generate snmp compatible response
+    public function format_response($oid, $type, $data)
+    {
+        return "{$oid}\n{$type}\n{$data}\n";
+    }
 
-				if(is_a($unserial,"litespeed_stats")) {
-					$this->stats = $unserial;
-				}
-				else {
-					$this->stats = new litespeed_stats($this->processes,$this->report_path);
-					$this->stats->parse();
-					$this->save_cache($this->cache_file, $this->stats);
-				}
-			}
-			else {
-				$this->stats = new litespeed_stats($this->processes,$this->report_path);
-				$this->stats->parse();
-				$this->save_cache($this->cache_file, $this->stats);
-			}
-		}
-		else {
-			$this->stats = new litespeed_stats($this->processes,$this->report_path);
-			$this->stats->parse();
-		}
-	}
+    //aggregate oid info from 1 to 7 sector
+    public function oid_part($tarray = null)
+    {
+        $str = "";
+        for($i=1; $i <= 7; $i++) {
+            $str .= "." . $tarray[$i];
+        }
 
-	//generate snmp compatible response
-	public function format_response($oid, $type, $data) {
-		return "{$oid}\n{$type}\n{$data}\n";
-	}
+        return $str;
+    }
 
-	//aggregate oid info from 1 to 7 sector
-	public function oid_part($tarray = null) {
-		$str = "";
-		for($i=1; $i <= 7; $i++) {
-			$str .= "." . $tarray[$i];
-		}
+    //retrieve single oid data
+    public function oid_get($super, $oid)
+    {
+        $parsed = explode(".",$oid);
 
-		return $str;
-	}
+        //error..invalid oid parse
+        if(count($parsed) < 9) {
+            return;
+        }
 
-	//retrieve single oid data
-	public function oid_get($super, $oid) {
+        $major = (int) $parsed[8];
 
+        if(count($parsed) < 10) {
+            $minor = 1;
+        } else {
+            $minor =  (int) $parsed[9];
+        }
 
-		$parsed = explode(".",$oid);
+        foreach($super as $key => $value) {
+            $sanitized_major = (int) substr($major,0,1) . "00";
 
-		//error..invalid oid parse
-		if(count($parsed) < 9) {
-			return;
-		}
-		
-		$major = (int) $parsed[8];
+            //index only
+            if( $major == (int) $key ) {
+                return $this->format_response($this->oid_part($parsed) . "." . $major . "." . $minor,"integer",$minor);
 
-		if(count($parsed) < 10) {
-			$minor = 1;
-		}
-		else {
-			$minor =  (int) $parsed[9];
-		}
+            }
 
-		foreach($super as $key => $value) {
-			$sanitized_major = (int) substr($major,0,1) . "00";
+            //non-index value
+            if( $sanitized_major == (int) $key) {
+                $size = count($value[0]);
 
-			//index only
-			if( $major == (int) $key ) {
-				return $this->format_response($this->oid_part($parsed) . "." . $major . "." . $minor,"integer",$minor);
+                $map = $value[1];
 
-			}
+                if($size <= 0) {
+                    return null;
+                }
 
-			//non-index value
-			if( $sanitized_major == (int) $key) {
-				$size = count($value[0]);
+                if(count($parsed) == 10) {
+                    if($minor > 0 && $minor <= $size) {
+                        $tempkeys = array_keys($value[0]);
+                        $temp = $value[0][$tempkeys[$minor-1]];
+                        list($format,$itemkey) = explode(",",$value[1][$major]);
 
-				$map = $value[1];
+                        return $this->format_response($oid, $format, $temp->$itemkey);
+                    }
+                }
+            }
+        }
+    }
 
-				if($size <= 0) {
-					return null;
-				}
+    public function save_cache($file, $data)
+    {
+        file_put_contents($file, serialize($data));
+    }
 
-				if(count($parsed) == 10) {
+    public function process($type, $oid)
+    {
+        //setup oid to var maps
+        $vh_map = array(
+            "201" => "string,vhost",
+            "202" => "gauge,req_processing",
+            "203" => "gauge,req_per_sec",
+            "204" => "counter,req_total"
+        );
 
-					if($minor > 0 && $minor <= $size) {
-						$tempkeys = array_keys($value[0]);
-						$temp = $value[0][$tempkeys[$minor-1]];
-						list($format,$itemkey) = explode(",",$value[1][$major]);
-						return $this->format_response($oid, $format, $temp->$itemkey);
-					}
-				}
-			}
-		}
-	}
+        $ext_map = array(
+            "301" => "string,vhost",
+            "302" => "string,type",
+            "303" => "string,extapp",
+            "304" => "gauge,config_max_conn",
+            "305" => "gauge,effect_max_conn",
+            "306" => "gauge,pool_size",
+            "307" => "gauge,inuse_conn",
+            "308" => "gauge,idle_conn",
+            "309" => "gauge,waitqueue_depth",
+            "310" => "gauge,req_per_sec",
+            "311" => "counter,req_total"
+        );
 
+        $gen_map = array(
+            "101" => "string,product",
+            "102" => "string,edition",
+            "103" => "string,version",
+            "104" => "string,uptime",
+            "105" => "gauge,bps_in",
+            "106" => "gauge,bps_out",
+            "107" => "gauge,ssl_bps_in",
+            "108" => "gauge,ssl_bps_out",
+            "109" => "gauge,max_conn",
+            "110" => "gauge,max_ssl_conn",
+            "111" => "gauge,plain_conn",
+            "112" => "gauge,avail_conn",
+            "113" => "gauge,idle_conn",
+            "114" => "gauge,ssl_conn",
+            "115" => "gauge,avail_ssl_conn"
+        );
 
-	public function save_cache($file, $data) {
-		file_put_contents($file, serialize($data));
-	}
+        //setup pointers
+        $super = array();
+        $super["100"] = array(array($this->stats), $gen_map);
+        $super["200"] = array($this->stats->vhosts, $vh_map);
 
+        //put alll extapps to single array
+        $extapps = array();
+        foreach($this->stats->vhosts as $value) {
+            foreach($value->extapps as $vextapp) {
+                $extapps[] = $vextapp;
+            }
+        }
 
-	public function process($type, $oid) {
-		
-		//setup oid to var maps
-		$vh_map = array(
-		"201" => "string,vhost",
-		"202" => "gauge,req_processing",
-		"203" => "gauge,req_per_sec",
-		"204" => "counter,req_total"
-		);
+        $super["300"] = array($extapps, $ext_map);
 
-		$ext_map = array(
-		"301" => "string,vhost",
-		"302" => "string,type",
-		"303" => "string,extapp",
-		"304" => "gauge,config_max_conn",
-		"305" => "gauge,effect_max_conn",
-		"306" => "gauge,pool_size",
-		"307" => "gauge,inuse_conn",
-		"308" => "gauge,idle_conn",
-		"309" => "gauge,waitqueue_depth",
-		"310" => "gauge,req_per_sec",
-		"311" => "counter,req_total"
-		);
+        //get single method
+        if($type == "-g") {
+            echo $this->oid_get($super, $oid);
+            return;
+        } else if($type == "-n") {
+            //snmp walk traversal
+            //build traversal nodes/oids
+            $parsed = explode(".",$oid);
+            $major = $parsed[8];
 
-		$gen_map = array(
-		"101" => "string,product",
-		"102" => "string,edition",
-		"103" => "string,version",
-		"104" => "string,uptime",
-		"105" => "gauge,bps_in",
-		"106" => "gauge,bps_out",
-		"107" => "gauge,ssl_bps_in",
-		"108" => "gauge,ssl_bps_out",
-		"109" => "gauge,max_conn",
-		"110" => "gauge,max_ssl_conn",
-		"111" => "gauge,plain_conn",
-		"112" => "gauge,avail_conn",
-		"113" => "gauge,idle_conn",
-		"114" => "gauge,ssl_conn",
-		"115" => "gauge,avail_ssl_conn"
-		);
+            foreach($super as $key => $value) {
+                //form index walk
+                if($major == $key) {
+                    $size = count($value[0]);
 
+                    if($size <= 0) {
+                        return;
+                    }
 
-		//setup pointers
-		$super = array();
-		$super["100"] = array(array($this->stats), $gen_map);
-		$super["200"] = array($this->stats->vhosts, $vh_map);
+                    if(count($parsed) == 10) {
+                        $minor = (int) $parsed[9];
 
-		//put alll extapps to single array
-		$extapps = array();
-		foreach($this->stats->vhosts as $value) {
-			foreach($value->extapps as $vextapp) {
-				$extapps[] = $vextapp;
-			}
-		}
+                        if($minor > 0 && $minor < $size) {
+                            echo $this->format_response($this->oid_part($parsed).".{$key}.".($minor+1),"integer",$minor+1);
 
-		$super["300"] = array($extapps, $ext_map);
+                        }
+                    } else if(count($parsed) == 9) {
+                        echo $this->format_response("{$oid}.1","integer",1);
+                    }
 
-		//get single method
-		if($type == "-g") {
-			echo $this->oid_get($super, $oid);
-			return;
-		}
+                } else if(array_key_exists($major,$value[1])) {
+                    //data walk
+                    $size = count($value[0]);
 
-		//snmp walk traversal
-		else if($type == "-n") {
-			//build traversal nodes/oids
-			$parsed = explode(".",$oid);
-			$major = $parsed[8];
+                    if($size <= 0) {
+                        return;
+                    }
 
+                    if(count($parsed) == 10) {
+                        $minor = (int) $parsed[9];
 
-			foreach($super as $key => $value) {
-
-				//form index walk
-				if($major == $key) {
-					$size = count($value[0]);
-
-					if($size <= 0) {
-						return;
-					}
-
-					if(count($parsed) == 10) {
-						$minor = (int) $parsed[9];
-
-						if($minor > 0 && $minor < $size) {
-							echo $this->format_response($this->oid_part($parsed).".{$key}.".($minor+1),"integer",$minor+1);
-
-						}
-					}
-					else if(count($parsed) == 9){
-						echo $this->format_response("{$oid}.1","integer",1);
-					}
-
-				}
-
-				//data walk
-				else if(array_key_exists($major,$value[1])) {
-					$size = count($value[0]);
-
-					if($size <= 0) {
-						return;
-					}
-
-					if(count($parsed) == 10) {
-						$minor = (int) $parsed[9];
-
-						if($minor > 0 && $minor < $size) {
-							echo $this->oid_get($super, $this->oid_part($parsed).".{$major}.".($minor+1));
-
-
-						}
-					}
-					else if(count($parsed) == 9){
-						echo $this->oid_get($super, $this->oid_part($parsed).".{$major}.".(1));
-					}
-
-				}
-			}
-		}
-	}
-
+                        if($minor > 0 && $minor < $size) {
+                            echo $this->oid_get($super, $this->oid_part($parsed).".{$major}.".($minor+1));
+                        }
+                    } else if(count($parsed) == 9){
+                        echo $this->oid_get($super, $this->oid_part($parsed).".{$major}.".(1));
+                    }
+                }
+            }
+        }
+    }
 }
-
-?>

--- a/dist/add-ons/snmp_monitoring/class.litespeed_stats.php
+++ b/dist/add-ons/snmp_monitoring/class.litespeed_stats.php
@@ -22,200 +22,179 @@ Version: 1.0 @ 08/23/2006
 Contact: bug@litespeedtech.com
 Url: http://www.litespeedtech.com
 
-Requirement: 
+Requirement:
 
 1)LiteSpeed Web Server version >= 2.1.18
 2)PHP 5+
 ----------------------------------------*/
 
+class litespeed_stats
+{
+    public $product = null;
+    public $edition = null;
+    public $version = null;
+    public $uptime = null;
 
-class litespeed_stats {
+    public $bps_in = 0;
+    public $bps_out = 0;
+    public $ssl_bps_in = 0;
+    public $ssl_bps_out = 0;
 
-	public $product = null;
-	public $edition = null;
-	public $version = null;
-	public $uptime = null;
+    public $max_conn = 0;
+    public $max_ssl_conn = 0;
 
-	public $bps_in = 0;
-	public $bps_out = 0;
-	public $ssl_bps_in = 0;
-	public $ssl_bps_out = 0;
+    public $plain_conn = 0;
+    public $avail_conn = 0;
+    public $idle_conn = 0;
 
-	public $max_conn = 0;
-	public $max_ssl_conn = 0;
+    public $ssl_conn = 0;
+    public $avail_ssl_conn = 0;
 
-	public $plain_conn = 0;
-	public $avail_conn = 0;
-	public $idle_conn = 0;
+    public $vhosts = array();
 
-	public $ssl_conn = 0;
-	public $avail_ssl_conn = 0;
+    //misc settings
 
+    //full path to .rtreports files. different products have different paths
+    public $report_path = "/tmp/lshttpd/";
 
-	public $vhosts = array();
+    //processes..enterprise version can spawn proccess = cpu cores
+    public $processes = 1;
 
-	//misc settings
+    public function __construct($processes = 1, $report_path = "/tmp/lshttpd/")
+    {
+        $this->processes = (int) $processes;
+        $this->report_path = trim($report_path);
+    }
 
-	//full path to .rtreports files. different products have different paths
-	public $report_path = "/tmp/lshttpd/";
+    public function parse()
+    {
+        for ( $i = 1 ; $i <= $this->processes ; $i++ )
+        {
+            if ( $i > 1 ) {
+                $content = file_get_contents("{$this->report_path}.rtreport.{$i}");
+            } else {
+                $content = file_get_contents("{$this->report_path}.rtreport");
+            }
 
-	//processes..enterprise version can spawn proccess = cpu cores
-	public $processes = 1;
+            $result = array();
 
-	public function litespeed_stats($processes = 1, $report_path = "/tmp/lshttpd/") {
-		$this->processes = (int) $processes;
-		$this->report_path = trim($report_path);
+            $found = 0;
 
-	}
+            $found = preg_match_all("/VERSION: ([a-zA-Z0-9\ ]+)\/([a-zA-Z]*)\/([a-zA-Z0-9\.]+)\nUPTIME: ([0-9A-Za-z\ \:]+)\nBPS_IN:([0-9\ ]+), BPS_OUT:([0-9\ ]+), SSL_BPS_IN:([0-9\ ]+), SSL_BPS_OUT:([0-9\ ]+)\nMAXCONN:([0-9\ ]+), MAXSSL_CONN:([0-9\ ]+), PLAINCONN:([0-9\ ]+), AVAILCONN:([0-9\ ]+), IDLECONN:([0-9\ ]+), SSLCONN:([0-9\ ]+), AVAILSSL:([0-9\ ]+)/i", $content, $result);
 
-	public function parse() {
+            if($found == 1) {
+                $this->product = trim($result[1][0]);
+                $this->edition = trim($result[2][0]);
+                $this->version = trim($result[3][0]);
+                $this->uptime = trim($result[4][0]);
+                $this->bps_in += (int) $result[5][0];
+                $this->bps_out += (int) $result[6][0];
+                $this->ssl_bps_in += (int) $result[7][0];
+                $this->ssl_bps_out += (int) $result[8][0];
 
-		for ( $i = 1 ; $i <= $this->processes ; $i++ )
-		{
+                $this->max_conn += (int) $result[9][0];
+                $this->max_ssl_conn += (int) $result[10][0];
 
-			if ( $i > 1 ) {
-				$content = file_get_contents("{$this->report_path}.rtreport.{$i}");
-			}
-			else {
-				$content = file_get_contents("{$this->report_path}.rtreport");
-			}
+                $this->plain_conn += (int) $result[11][0];
+                $this->avail_conn += (int) $result[12][0];
+                $this->idle_conn += (int) $result[13][0];
 
-			$result = array();
+                $this->ssl_conn += (int) $result[14][0];
+                $this->avail_ssl_conn += (int) $result[15][0];
+            }
 
-			$found = 0;
+            $result = array();
+            $found = 0;
 
-			$found = preg_match_all("/VERSION: ([a-zA-Z0-9\ ]+)\/([a-zA-Z]*)\/([a-zA-Z0-9\.]+)\nUPTIME: ([0-9A-Za-z\ \:]+)\nBPS_IN:([0-9\ ]+), BPS_OUT:([0-9\ ]+), SSL_BPS_IN:([0-9\ ]+), SSL_BPS_OUT:([0-9\ ]+)\nMAXCONN:([0-9\ ]+), MAXSSL_CONN:([0-9\ ]+), PLAINCONN:([0-9\ ]+), AVAILCONN:([0-9\ ]+), IDLECONN:([0-9\ ]+), SSLCONN:([0-9\ ]+), AVAILSSL:([0-9\ ]+)/i", $content, $result);
+            $found = preg_match_all("/REQ_RATE \[([^\]]*)\]: REQ_PROCESSING: ([0-9]+), REQ_PER_SEC: ([0-9]+), TOT_REQS: ([0-9]+)/i",$content,$result);
 
-			if($found == 1) {
-				$this->product = trim($result[1][0]);
-				$this->edition = trim($result[2][0]);
-				$this->version = trim($result[3][0]);
-				$this->uptime = trim($result[4][0]);
-				$this->bps_in += (int) $result[5][0];
-				$this->bps_out += (int) $result[6][0];
-				$this->ssl_bps_in += (int) $result[7][0];
-				$this->ssl_bps_out += (int) $result[8][0];
+            for($f = 0; $f < $found; $f++) {
+                $vhost = trim($result[1][$f]);
 
-				$this->max_conn += (int) $result[9][0];
-				$this->max_ssl_conn += (int) $result[10][0];
+                if($vhost == "") {
+                    $vhost = "_Server";
+                }
 
-				$this->plain_conn += (int) $result[11][0];
-				$this->avail_conn += (int) $result[12][0];
-				$this->idle_conn += (int) $result[13][0];
+                if(!array_key_exists($vhost,$this->vhosts)) {
+                    $this->vhosts[$vhost] = new litespeed_stats_vhost($vhost);
+                }
 
-				$this->ssl_conn += (int) $result[14][0];
-				$this->avail_ssl_conn += (int) $result[15][0];
-			}
+                $temp = $this->vhosts[$vhost];
 
+                $temp->req_processing += (int) $result[2][$f];
+                $temp->req_per_sec += (int) $result[3][$f];
+                $temp->req_total += (int) $result[4][$f];
+            }
 
-			$result = array();
-			$found = 0;
+            //reset
+            $result = array();
+            $found = 0;
 
-			$found = preg_match_all("/REQ_RATE \[([^\]]*)\]: REQ_PROCESSING: ([0-9]+), REQ_PER_SEC: ([0-9]+), TOT_REQS: ([0-9]+)/i",$content,$result);
+            $found = preg_match_all("/EXTAPP \[([^\]]*)\] \[([^\]]*)\] \[([^\]]*)\]: CMAXCONN: ([0-9]+), EMAXCONN: ([0-9]+), POOL_SIZE: ([0-9]+), INUSE_CONN: ([0-9]+), IDLE_CONN: ([0-9]+), WAITQUE_DEPTH: ([0-9]+), REQ_PER_SEC: ([0-9]+), TOT_REQS: ([0-9]+)/i",$content,$result);
 
-			for($f = 0; $f < $found; $f++) {
-				$vhost = trim($result[1][$f]);
+            for($f = 0; $f < $found; $f++) {
+                $vhost = trim($result[2][$f]);
+                $extapp = trim($result[3][$f]);
 
-				if($vhost == "") {
-					$vhost = "_Server";
-				}
+                if($vhost == "") {
+                    $vhost = "_Server";
+                }
 
-				if(!array_key_exists($vhost,$this->vhosts)) {
-					$this->vhosts[$vhost] = new litespeed_stats_vhost($vhost);
-				}
+                if(!array_key_exists($vhost,$this->vhosts)) {
+                    $this->vhosts[$vhost] = new litespeed_stats_vhost($vhost);
+                }
 
-				$temp = $this->vhosts[$vhost];
+                if(!array_key_exists($extapp,$this->vhosts[$vhost]->extapps)) {
+                    $this->vhosts[$vhost]->extapps[$extapp] = new litespeed_stats_vhost_extapp($extapp, $vhost);
+                }
 
-				$temp->req_processing += (int) $result[2][$f];
-				$temp->req_per_sec += (int) $result[3][$f];
-				$temp->req_total += (int) $result[4][$f];
+                $temp = $this->vhosts[$vhost]->extapps[$extapp];
 
-			}
-
-			//reset
-			$result = array();
-			$found = 0;
-
-			$found = preg_match_all("/EXTAPP \[([^\]]*)\] \[([^\]]*)\] \[([^\]]*)\]: CMAXCONN: ([0-9]+), EMAXCONN: ([0-9]+), POOL_SIZE: ([0-9]+), INUSE_CONN: ([0-9]+), IDLE_CONN: ([0-9]+), WAITQUE_DEPTH: ([0-9]+), REQ_PER_SEC: ([0-9]+), TOT_REQS: ([0-9]+)/i",$content,$result);
-
-			for($f = 0; $f < $found; $f++) {
-				$vhost = trim($result[2][$f]);
-				$extapp = trim($result[3][$f]);
-
-				if($vhost == "") {
-					$vhost = "_Server";
-				}
-
-				if(!array_key_exists($vhost,$this->vhosts)) {
-					$this->vhosts[$vhost] = new litespeed_stats_vhost($vhost);
-				}
-
-
-
-				if(!array_key_exists($extapp,$this->vhosts[$vhost]->extapps)) {
-					$this->vhosts[$vhost]->extapps[$extapp] = new litespeed_stats_vhost_extapp($extapp, $vhost);
-				}
-
-				$temp = $this->vhosts[$vhost]->extapps[$extapp];
-
-				$temp->type = trim($result[1][$f]);
-				$temp->config_max_conn += (int) $result[4][$f];
-				$temp->effect_max_conn += (int) $result[5][$f];
-				$temp->pool_size += (int) $result[6][$f];
-				$temp->inuse_conn += (int) $result[7][$f];
-				$temp->idle_conn += (int) $result[8][$f];
-				$temp->waitqueue_depth += (int) $result[9][$f];
-				$temp->req_per_sec += (int) $result[10][$f];
-				$temp->req_total += (int) $result[11][$f];
-
-
-			}
-
-		}
-
-
-
-	}
-
-
-
+                $temp->type = trim($result[1][$f]);
+                $temp->config_max_conn += (int) $result[4][$f];
+                $temp->effect_max_conn += (int) $result[5][$f];
+                $temp->pool_size += (int) $result[6][$f];
+                $temp->inuse_conn += (int) $result[7][$f];
+                $temp->idle_conn += (int) $result[8][$f];
+                $temp->waitqueue_depth += (int) $result[9][$f];
+                $temp->req_per_sec += (int) $result[10][$f];
+                $temp->req_total += (int) $result[11][$f];
+            }
+        }
+    }
 }
 
-class liteSpeed_stats_vhost {
+class liteSpeed_stats_vhost
+{
+    public $vhost = null;
+    public $req_processing = 0;
+    public $req_per_sec = 0;
+    public $req_total = 0;
+    public $extapps = array();
 
-	public $vhost = null;
-	public $req_processing = 0;
-	public $req_per_sec = 0;
-	public $req_total = 0;
-	public $extapps = array();
-
-	public function litespeed_stats_vhost($vhost = null) {
-		$this->vhost = trim($vhost);
-	}
-
+    public function __construct($vhost = null)
+    {
+        $this->vhost = trim($vhost);
+    }
 }
 
-class litespeed_stats_vhost_extapp {
+class litespeed_stats_vhost_extapp
+{
+    public function __construct($extapp = null, $vhost = null)
+    {
+        $this->extapp = trim($extapp);
+        $this->vhost = trim($vhost);
+    }
 
-	public function litespeed_stats_vhost_extApp($extapp = null, $vhost = null) {
-		$this->extapp = trim($extapp);
-		$this->vhost = trim($vhost);
-	}
-
-	public $vhost = null;
-	public $type = null;
-	public $extapp = null;
-	public $config_max_conn = 0;
-	public $effect_max_conn = 0;
-	public $pool_size = 0;
-	public $inuse_conn = 0;
-	public $idle_conn = 0;
-	public $waitqueue_depth = 0;
-	public $req_per_sec = 0;
-	public $req_total = 0;
-
+    public $vhost = null;
+    public $type = null;
+    public $extapp = null;
+    public $config_max_conn = 0;
+    public $effect_max_conn = 0;
+    public $pool_size = 0;
+    public $inuse_conn = 0;
+    public $idle_conn = 0;
+    public $waitqueue_depth = 0;
+    public $req_per_sec = 0;
+    public $req_total = 0;
 }
-
-
-
-?>


### PR DESCRIPTION
This patch fixes some coding style and class constructors in SNMP monitoring add on PHP classes to avoid raising E_DEPRECATED in PHP 7.

Thank you for considering merging it.