### PR TITLE
Change constructor of jCryption to current PHP style

### DIFF
--- a/dist/admin/html.open/lib/jCryption.php
+++ b/dist/admin/html.open/lib/jCryption.php
@@ -32,7 +32,7 @@
 		*
 		* @access public
 		*/
-		function jCryption($e = "\x01\x00\x01") {
+		public function __construct($e = "\x01\x00\x01") {
 			$this->_e = $e;
 		}
 


### PR DESCRIPTION
In PHP 8 constructors with the same name as classes won't work anymore so this patch fixes the deprecation warning when using PHP 7+.