### PR TITLE
Fix for gcc version 7.1.1 (Red Hat 7.1.1-3)

### DIFF
--- a/src/util/gmap.h
+++ b/src/util/gmap.h
@@ -72,7 +72,10 @@ public:
     {
         return (iterator)(*find_fn)(this, pKey);
     }
-
+    const_iterator find(const void *pKey) const
+    {
+        return (const_iterator)(*find_fn)((GMap *)this,pKey);
+    }
     int insert(const void *pKey, void *pValue)
     {
         return (*insert_fn)(this, pKey, pValue);


### PR DESCRIPTION
build on Fedora 26, using gcc version 7.1.1 20170622 (Red Hat 7.1.1-3) (GCC).
Got error :
../../src/util/gmap.h:71:14: note:   passing ‘const TMap<T>*’ as ‘this’ argument discards qualifiers
so I declared const_iterator, built successfully.