### PR TITLE
Remove old and unused .cvsignore file

### DIFF
--- a/src/.cvsignore
+++ b/src/.cvsignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.moc.cpp
-*.moc


### PR DESCRIPTION
Hello, this file is probably not used anywhere in this repository. The `.cvsignore` file was used in CVS...