### PR TITLE
Replace AM_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT([openlitespeed],[1.5.0],[info@litespeedtech.com],[openlitespeed],[http://www.litespeedtech.com/])
 AM_INIT_AUTOMAKE([1.0 foreign no-define ])
 
-AM_CONFIG_HEADER(src/config.h:src/config.h.in)
+AC_CONFIG_HEADERS([src/config.h:src/config.h.in])
 
 dnl NOW change the default installation directory!
 AC_PREFIX_DEFAULT('/usr/local/lsws')


### PR DESCRIPTION
The `AM_CONFIG_HEADER` macro is part of automake and has been removed in version 1.13.0 and then readded back in the 1.13.2. Originally it was superseded by the AC_CONFIG_HEADERS macro since July 2002. Since most likely this macro will be removed in the future versions it probably makes sence to now replace it. Also the configure script is pregenerated and shipped with OpenLiteSpeed so the minimal requirements are even less problematic here.

Refs: 

* http://git.savannah.gnu.org/cgit/automake.git/tree/NEWS
* https://www.gnu.org/software/automake/manual/html_node/Optional.html
* https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Configuration-Headers.html

Thanks.