### PR TITLE
"OS is Linux, APP_MGR_CMD is yum." Is displayed for all Linux distributions.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ fi
 
 APP_MGR_CMD=
 for APP_MGR in ${APP_MGRS}; do
-  APP_MGR_CHECK=`which ${APP_MGR} &>/dev/null`
+  APP_MGR_CHECK=`which ${APP_MGR}`
   if [ $? -eq 0 ] ; then
     APP_MGR_CMD="${APP_MGR}"
     break


### PR DESCRIPTION
The expected behavior is that the Install command changes depending on the Linux distribution.

Ubuntu
```
OS is Linux, APP_MGR_CMD is apt
```

Debian
```
OS is Linux, APP_MGR_CMD is apt
```

openSUSE
```
OS is Linux, APP_MGR_CMD is zypper
```

Amazon Linux 2
```
OS is Linux, APP_MGR_CMD is yum
```

However, the actual operation does not change the Install command in all distributions.
```
OS is Linux, APP_MGR_CMD is yum
```