### PR TITLE
support alpine linux(musl-libc) by build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ VERSIONNUMBER=
 if [ "${OS}" = "FreeBSD" ] ; then
     APP_MGRS="pkg"
 elif [ "${OS}" = "Linux" ] ; then
-    APP_MGRS="yum apt apt-get zypper"
+    APP_MGRS="yum apt apt-get zypper apk"
 elif [ "${OS}" = "Darwin" ] ; then
     APP_MGRS="port brew"
 else
@@ -79,7 +79,12 @@ getVersionNumber()
 
 installCmake()
 {
-    ${APP_MGR_CMD} -y install git cmake
+    if [ "${APP_MGR_CMD}" = "apk" ] ; then
+        ${APP_MGR_CMD} add --update git cmake
+    else
+        ${APP_MGR_CMD} -y install git cmake
+    fi
+
     if [ $? = 0 ] ; then
         CMAKEVER=`cmake --version | grep version | awk  '{print $3}'`
         getVersionNumber $CMAKEVER
@@ -108,7 +113,12 @@ installCmake()
 
 installgo()
 {
-    ${APP_MGR_CMD} -y install golang-go
+    if [ "${APP_MGR_CMD}" = "apk" ] ; then
+        ${APP_MGR_CMD} add --update go
+    else
+        ${APP_MGR_CMD} -y install golang-go
+    fi
+
     if [ $? = 0 ] ; then
         echo go installed.
     else
@@ -279,6 +289,21 @@ prepareLinux()
 
         
         
+    elif [ -f /etc/alpine-release ] ; then
+        OSTYPE=ALPINE
+        ${APP_MGR_CMD} add make
+        ${APP_MGR_CMD} add gcc g++
+        ${APP_MGR_CMD} add patch
+        installCmake
+        ${APP_MGR_CMD} add git libtool linux-headers bsd-compat-headers curl
+        ${APP_MGR_CMD} add automake autoconf
+        ${APP_MGR_CMD} add build-base expat-dev zlib-dev
+        installgo
+        sed -i -e "s/u_int32_t/uint32_t/g" $(grep -rl u_int32_t src/)
+        sed -i -e "s/u_int64_t/uint64_t/g" $(grep -rl u_int64_t src/)
+        sed -i -e "s/u_int8_t/uint8_t/g" $(grep -rl u_int8_t src/)
+        sed -i -e "s@<sys/sysctl.h>@<linux/sysctl.h>@g" $(grep -rl "<sys/sysctl.h>" src/)
+        sed -i -e "s/PTHREAD_MUTEX_ADAPTIVE_NP/PTHREAD_MUTEX_NORMAL/g" src/lsr/ls_lock.c
     else 
         echo May not support your platform, but we can do a try to install some tools.
         ${APP_MGR_CMD} -y update
@@ -394,6 +419,10 @@ updateSrcCMakelistfile()
         sed -i -e "s/-Wl,--whole-archive//g"  src/CMakeLists.txt
         sed -i -e "s/-Wl,--no-whole-archive//g"  src/CMakeLists.txt
     fi
+
+    if [ "${OSTYPE}" = "ALPINE" ] ; then
+        sed -i -e "s/c_nonshared//g"  src/CMakeLists.txt
+    fi
     
 }
 
@@ -412,7 +441,9 @@ updateModuleCMakelistfile()
     fi
     
     if [ "${ISLINUX}" = "yes" ] ; then
-        echo "add_subdirectory(pagespeed)" >> src/modules/CMakeLists.txt
+        if [ ! "${OSTYPE}" = "ALPINE" ] ; then
+            echo "add_subdirectory(pagespeed)" >> src/modules/CMakeLists.txt
+        fi
     
     fi
     
@@ -514,10 +545,11 @@ cd ../../../
 #Done of modsecurity
 
 fixshmdir
-
+set -e
 cmake .
 make
 cp src/openlitespeed  dist/bin/
+set +x
 
 cpModuleSoFiles
 

--- a/src/thread/pthreadmutex.cpp
+++ b/src/thread/pthreadmutex.cpp
@@ -16,7 +16,7 @@
 *    along with this program. If not, see http://www.gnu.org/licenses/.      *
 *****************************************************************************/
 #include "pthreadmutex.h"
-#if (defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)) && !defined( NDEBUG )
+#if (defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)) && !defined( NDEBUG ) && defined(PTHREAD_MUTEX_ERRORCHECK_NP)
 
 #ifndef PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP
 # define PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP \

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -119,11 +119,13 @@ public:
     int timedJoin(void **pRetVal, struct timespec *timeout)
     {   return pthread_timedjoin_np(m_thread, pRetVal, timeout);    }
 
+#ifdef __gnu_linux__
     int attrSetAffinity(size_t cpusetsize, const cpu_set_t *cpuset)
     {   return m_thread ? LS_FAIL : pthread_attr_setaffinity_np(&m_attr, cpusetsize, cpuset);  }
 
     int attrGetAffinity(size_t cpusetsize, cpu_set_t *pCpuSet)
     {   return pthread_attr_getaffinity_np(&m_attr, cpusetsize, pCpuSet);  }
+#endif
 #endif
 
     int attrSetDetachState(int detachstate)


### PR DESCRIPTION
alpine liunx uses musl-libc, and apk as package manager.

With this change, the bin/openlitespeed build worked.
However, all the modules do not work.