### PR TITLE
Fix UPDATE http method length

### DIFF
--- a/src/http/httpmethod.cpp
+++ b/src/http/httpmethod.cpp
@@ -59,7 +59,7 @@ const char *HttpMethod::s_psMethod[HttpMethod::HTTP_METHOD_END] =
 int HttpMethod::s_iMethodLen[HttpMethod::HTTP_METHOD_END] =
 {
     7, 7, 3, 4, 4, 3, 6, 5, 7, 4, 5,
-    8, 9, 5, 4, 4, 6, 15, 6, 7, 8, 10, 7, 11, 5, 5, 16, 10, 4, 6, 5, 7
+    8, 9, 5, 4, 4, 6, 15, 6, 7, 8, 10, 6, 11, 5, 5, 16, 10, 4, 6, 5, 7
 };
 
 http_method_t HttpMethod::parse2(const char *pMethod)


### PR DESCRIPTION
A typo I found in the code.
The `UPDATE` http method is 6 bytes, not 7.