### PR TITLE
Fix load avg having too many numbers of decimals

### DIFF
--- a/dist/admin/html.open/view/UIBase.php
+++ b/dist/admin/html.open/view/UIBase.php
@@ -76,7 +76,7 @@ class UIBase
 
 	public static function content_header($icon, $title, $subtitle='')
 	{
-		$serverload = implode(', ', sys_getloadavg());
+		$serverload = implode(', ', array_map(function($load) { return round($load, 5); }, \sys_getloadavg()));
 		$pid = Service::ServiceData(SInfo::DATA_PID);
 
 		if ($subtitle != '')

--- a/dist/admin/html.open/view/ajax_data.php
+++ b/dist/admin/html.open/view/ajax_data.php
@@ -10,7 +10,7 @@ require_once('inc/auth.php') ;
 function ajax_pid_load()
 {
     $data = array( 'pid' => Service::ServiceData(SInfo::DATA_PID),
-        'serverload' => implode(', ', sys_getloadavg()) ) ;
+        'serverload' => implode(', ', array_map(function($load) { return round($load, 5); }, \sys_getloadavg())) ) ;
     echo json_encode($data) ;
 }
 


### PR DESCRIPTION
Sometimes when load avg have to many numbers of decimals it breaks UI:

![Screenshot from 2022-06-24 13-13-25](https://user-images.githubusercontent.com/62944093/175523571-009e6a7e-4e83-4d02-b878-a3e412026164.png)

This commit force load to have max 5 decimal numbers.