### PR TITLE
Updated copyright to 2022

### DIFF
--- a/dist/add-ons/webcachemgr/src/CliController.php
+++ b/dist/add-ons/webcachemgr/src/CliController.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright (c) 2018-2021
+ * @copyright (c) 2018-2022
  * ******************************************* */
 
 namespace Lsc\Wp;

--- a/dist/add-ons/webcachemgr/src/Panel/CustomPanelBase.php
+++ b/dist/add-ons/webcachemgr/src/Panel/CustomPanelBase.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright (c) 2020-2021
+ * @copyright (c) 2020-2022
  * @since 1.10
  * ******************************************* */
 

--- a/dist/add-ons/webcachemgr/src/Panel/DirectAdmin.php
+++ b/dist/add-ons/webcachemgr/src/Panel/DirectAdmin.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author: LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright: (c) 2019-2021
+ * @copyright: (c) 2019-2022
  * ******************************************* */
 
 namespace Lsc\Wp\Panel;

--- a/dist/add-ons/webcachemgr/src/Panel/Plesk.php
+++ b/dist/add-ons/webcachemgr/src/Panel/Plesk.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright (c) 2018-2021
+ * @copyright (c) 2018-2022
  * ******************************************* */
 
 namespace Lsc\Wp\Panel;

--- a/dist/add-ons/webcachemgr/src/RedefineGlobalFuncs.php
+++ b/dist/add-ons/webcachemgr/src/RedefineGlobalFuncs.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright (c) 2021
+ * @copyright (c) 2022
  * @since 1.13.10
  * *******************************************
  */

--- a/dist/add-ons/webcachemgr/src/WPInstallStorage.php
+++ b/dist/add-ons/webcachemgr/src/WPInstallStorage.php
@@ -4,7 +4,7 @@
  * LiteSpeed Web Server Cache Manager
  *
  * @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
- * @copyright (c) 2018-2021
+ * @copyright (c) 2018-2022
  * *******************************************
  */
 

--- a/dist/admin/misc/lscmctl
+++ b/dist/admin/misc/lscmctl
@@ -4,7 +4,7 @@
 # LiteSpeed Cache Management Script
 #
 # @author LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
-# @copyright (c) 2017-2021
+# @copyright (c) 2017-2022
 # *********************************************/
 
 VERSION='1.11.2'

--- a/include/ls.h
+++ b/include/ls.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsdef.h
+++ b/include/lsdef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_aho.h
+++ b/include/lsr/ls_aho.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -122,7 +122,7 @@ void ls_aho_delete(ls_aho_t *pThis);
  *
  * @see ls_aho_new, ls_aho, ls_aho_maketree
  */
-int ls_aho_addpattern(ls_aho_t *pThis, const char *pattern, size_t size, 
+int ls_aho_addpattern(ls_aho_t *pThis, const char *pattern, size_t size,
                       void *pattern_ctx);
 
 /** @ls_aho_addfromfile
@@ -195,9 +195,9 @@ int ls_aho_optimizetree(ls_aho_t *pThis);
  * @see ls_aho_optimizetree
  */
 unsigned int ls_aho_search(ls_aho_t *pThis,
-                           ls_aho_state_t *start_state, const char *string, 
+                           ls_aho_state_t *start_state, const char *string,
                            size_t size, size_t startpos,
-                           size_t *out_start, size_t *out_end, 
+                           size_t *out_start, size_t *out_end,
                            ls_aho_state_t **out_last_state, void **pattern_ctx);
 
 ls_aho_t *ls_aho_copy(ls_aho_t *pThis);

--- a/include/lsr/ls_base64.h
+++ b/include/lsr/ls_base64.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_buf.h
+++ b/include/lsr/ls_buf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_confparser.h
+++ b/include/lsr/ls_confparser.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_crc64.h
+++ b/include/lsr/ls_crc64.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_dlinkq.h
+++ b/include/lsr/ls_dlinkq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_edio.h
+++ b/include/lsr/ls_edio.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_fileio.h
+++ b/include/lsr/ls_fileio.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_hash.h
+++ b/include/lsr/ls_hash.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -467,9 +467,9 @@ int ls_hash_foreach2(ls_hash_t *pThis,
                      void *pUData);
 
 
-void ls_hash_release_objects(ls_hash_t *pThis, 
-                             void (*release_object)(void *pKey, void *pData, 
-                                                    void *ctx), 
+void ls_hash_release_objects(ls_hash_t *pThis,
+                             void (*release_object)(void *pKey, void *pData,
+                                                    void *ctx),
                              void *ctx);
 
 

--- a/include/lsr/ls_lfqueue.h
+++ b/include/lsr/ls_lfqueue.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_lfstack.h
+++ b/include/lsr/ls_lfstack.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_link.h
+++ b/include/lsr/ls_link.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_llmq.h
+++ b/include/lsr/ls_llmq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_llxq.h
+++ b/include/lsr/ls_llxq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_log.h
+++ b/include/lsr/ls_log.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_loopbuf.h
+++ b/include/lsr/ls_loopbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_map.h
+++ b/include/lsr/ls_map.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_md5.h
+++ b/include/lsr/ls_md5.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_node.h
+++ b/include/lsr/ls_node.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_objarray.h
+++ b/include/lsr/ls_objarray.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_objpool.h
+++ b/include/lsr/ls_objpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_pcreg.h
+++ b/include/lsr/ls_pcreg.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_pool.h
+++ b/include/lsr/ls_pool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -112,11 +112,11 @@ char *ls_pdupstr(const char *p);
  * @ls_preserve
  * @brief Changes the size of a block of memory allocated
  *   from the global memory pool.
- * @details If new_sz is equal or smaller than the current 
+ * @details If new_sz is equal or smaller than the current
  *   memory block size, the old memory block wont be changed.
  *   If the memory size is increasing, the contents will NOT be copied to new
- *   memory block, if need to keep old content unchanged, use ls_prealloc 
- *   instead. 
+ *   memory block, if need to keep old content unchanged, use ls_prealloc
+ *   instead.
  *   If the current pointer \e pOld argument is NULL, ls_preserve effectively
  *   becomes ls_palloc to allocate new memory.
  *

--- a/include/lsr/ls_ptrlist.h
+++ b/include/lsr/ls_ptrlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_sha1.h
+++ b/include/lsr/ls_sha1.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_shm.h
+++ b/include/lsr/ls_shm.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_stack.h
+++ b/include/lsr/ls_stack.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_str.h
+++ b/include/lsr/ls_str.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_strlist.h
+++ b/include/lsr/ls_strlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_strtool.h
+++ b/include/lsr/ls_strtool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_swap.h
+++ b/include/lsr/ls_swap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_time.h
+++ b/include/lsr/ls_time.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_tsstack.h
+++ b/include/lsr/ls_tsstack.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_types.h
+++ b/include/lsr/ls_types.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/include/lsr/ls_xpool.h
+++ b/include/lsr/ls_xpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/adns/adns.cpp
+++ b/src/adns/adns.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -225,7 +225,7 @@ void Adns::release(AdnsReq *pReq)
         return;
     if (--pReq->ref_count == 0)
     {
-        //fprintf(stderr, "release AdnsReq %p\n", pReq); 
+        //fprintf(stderr, "release AdnsReq %p\n", pReq);
         delete pReq;
     }
 }
@@ -341,8 +341,8 @@ void Adns::getHostByAddrCb(struct dns_ctx *ctx, struct dns_rr_ptr *rr, void *par
     if (pAdnsReq->cb && pAdnsReq->arg)
         pAdnsReq->cb(pAdnsReq->arg, n, p);
     //else
-    //    fprintf(stderr, "AdnsReq %p for %s skip callback, cb: %p, arg: %p\n", 
-    //            pAdnsReq, pAdnsReq->name, pAdnsReq->cb, pAdnsReq->arg); 
+    //    fprintf(stderr, "AdnsReq %p for %s skip callback, cb: %p, arg: %p\n",
+    //            pAdnsReq, pAdnsReq->name, pAdnsReq->cb, pAdnsReq->arg);
 
     if (rr)
         free(rr);
@@ -372,7 +372,7 @@ const char *Adns::getHostByNameInCache(const char * pName, int &length,
 }
 
 
-AdnsReq *Adns::getHostByName(const char * pName, int type, 
+AdnsReq *Adns::getHostByName(const char * pName, int type,
                              lookup_pf cb, void *arg)
 {
     dns_query * pQuery;
@@ -380,8 +380,8 @@ AdnsReq *Adns::getHostByName(const char * pName, int type,
     AdnsReq *pAdnsReq = new AdnsReq;
     if (!pAdnsReq)
         return NULL;
-    //fprintf(stderr, "AdnsReq %p created for getHostByName %s\n", 
-    //        pAdnsReq, pName); 
+    //fprintf(stderr, "AdnsReq %p created for getHostByName %s\n",
+    //        pAdnsReq, pName);
     pAdnsReq->type = type;
     pAdnsReq->name = getCacheName(pName, type);
     pAdnsReq->cb = cb;
@@ -441,7 +441,7 @@ AdnsReq * Adns::getHostByAddr(const struct sockaddr * pAddr, void *arg, lookup_p
     if (!pAdnsReq)
         return NULL;
 
-    //fprintf(stderr, "AdnsReq %p created for getHostByAddr\n", pAdnsReq); 
+    //fprintf(stderr, "AdnsReq %p created for getHostByAddr\n", pAdnsReq);
     int type = pAddr->sa_family;
     pAdnsReq->type = type;
     int length;

--- a/src/adns/adns.h
+++ b/src/adns/adns.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -121,7 +121,7 @@ public:
 
     static int  deleteCache();
     void        trimCache();
-    
+
     char *getCacheName(const char *pName, int type);
     const char *getCacheValue(const char * pName, int nameLen, int &valLen,
                                int max_ttl = 0);
@@ -135,10 +135,10 @@ public:
     const char *getHostByAddrInCache(const struct sockaddr * pAddr,
                                      int &length, int max_ttl = 0);
     AdnsReq *getHostByAddr(const struct sockaddr * pAddr, void *arg, lookup_pf cb);
-    
+
     static int setResult(const struct sockaddr *result, const void *ip, int len);
     static void release(AdnsReq *pReq);
-    
+
 
     int  handleEvents(short events);
     int  onTimer();
@@ -148,7 +148,7 @@ public:
     static int getHostByNameV6Sync(const char *pName, in6_addr *addr);
 
     void       checkCacheTTL();
-    
+
     void       processPendingEvt()
     {}
 

--- a/src/edio/aioeventhandler.cpp
+++ b/src/edio/aioeventhandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/aioeventhandler.h
+++ b/src/edio/aioeventhandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/aiosendfile.cpp
+++ b/src/edio/aiosendfile.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/aiosendfile.h
+++ b/src/edio/aiosendfile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/bufferedos.cpp
+++ b/src/edio/bufferedos.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/bufferedos.h
+++ b/src/edio/bufferedos.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/cacheos.cpp
+++ b/src/edio/cacheos.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/cacheos.h
+++ b/src/edio/cacheos.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/callbackqueue.cpp
+++ b/src/edio/callbackqueue.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/callbackqueue.h
+++ b/src/edio/callbackqueue.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/devpoller.cpp
+++ b/src/edio/devpoller.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/devpoller.h
+++ b/src/edio/devpoller.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/ediostream.cpp
+++ b/src/edio/ediostream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/ediostream.h
+++ b/src/edio/ediostream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/epoll.cpp
+++ b/src/edio/epoll.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/epoll.h
+++ b/src/edio/epoll.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventhandler.h
+++ b/src/edio/eventhandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventnotifier.cpp
+++ b/src/edio/eventnotifier.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventnotifier.h
+++ b/src/edio/eventnotifier.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventprocessor.cpp
+++ b/src/edio/eventprocessor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventprocessor.h
+++ b/src/edio/eventprocessor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventreactor.cpp
+++ b/src/edio/eventreactor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/eventreactor.h
+++ b/src/edio/eventreactor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -42,7 +42,7 @@ public:
     typedef int (*pri_handler)();
     typedef void (*command_fn)(EventReactor *pThis);
 
-    EventReactor() 
+    EventReactor()
         : m_cntHup(0)
         , m_eventSet(0)
         , m_flags(0)
@@ -87,10 +87,10 @@ public:
     void clearRevent()                  {   m_pollfd.revents = 0;    }
     void assignRevent(short event)      {   m_pollfd.revents = event;}
     short getAssignedRevent()           {   return m_pollfd.revents; }
-    
+
     void updateEventSet()               {   m_eventSet = m_pfd->events;     }
     int  isApplyEvents() const          {   return m_eventSet != m_pfd->events;  }
-    
+
     void addFlag(unsigned short flag)   {   m_flags |= flag;        }
     void removeFlag(unsigned short flag){   m_flags &= ~flag;       }
     unsigned short getEvtFlag() const   {   return m_flags;         }

--- a/src/edio/evtcbque.cpp
+++ b/src/edio/evtcbque.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/evtcbque.h
+++ b/src/edio/evtcbque.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/fdindex.cpp
+++ b/src/edio/fdindex.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/fdindex.h
+++ b/src/edio/fdindex.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/flowcontrol.cpp
+++ b/src/edio/flowcontrol.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/flowcontrol.h
+++ b/src/edio/flowcontrol.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/inputstream.cpp
+++ b/src/edio/inputstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/inputstream.h
+++ b/src/edio/inputstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/iochain.cpp
+++ b/src/edio/iochain.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/iochain.h
+++ b/src/edio/iochain.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/kqueuer.cpp
+++ b/src/edio/kqueuer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -400,6 +400,6 @@ void KQueuer::wantWrite(EventReactor *pHandler, int want)
 }
 
 
-#endif //defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__) 
+#endif //defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__)
 //|| defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 

--- a/src/edio/kqueuer.h
+++ b/src/edio/kqueuer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -89,7 +89,7 @@ public:
 
 };
 
-#endif //defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__) 
+#endif //defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__)
 //|| defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 
 

--- a/src/edio/lookupfd.cpp
+++ b/src/edio/lookupfd.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/lookupfd.h
+++ b/src/edio/lookupfd.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/multiplexer.cpp
+++ b/src/edio/multiplexer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/multiplexer.h
+++ b/src/edio/multiplexer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/multiplexerfactory.cpp
+++ b/src/edio/multiplexerfactory.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/multiplexerfactory.h
+++ b/src/edio/multiplexerfactory.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/outputbuf.cpp
+++ b/src/edio/outputbuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/outputbuf.h
+++ b/src/edio/outputbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/outputstream.cpp
+++ b/src/edio/outputstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/outputstream.h
+++ b/src/edio/outputstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/poller.cpp
+++ b/src/edio/poller.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/poller.h
+++ b/src/edio/poller.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/pollfdreactor.cpp
+++ b/src/edio/pollfdreactor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/pollfdreactor.h
+++ b/src/edio/pollfdreactor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/reactorindex.cpp
+++ b/src/edio/reactorindex.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/reactorindex.h
+++ b/src/edio/reactorindex.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/rtsigio.cpp
+++ b/src/edio/rtsigio.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/rtsigio.h
+++ b/src/edio/rtsigio.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/sigeventdispatcher.cpp
+++ b/src/edio/sigeventdispatcher.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/edio/sigeventdispatcher.h
+++ b/src/edio/sigeventdispatcher.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgiconnection.cpp
+++ b/src/extensions/cgi/cgiconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgiconnection.h
+++ b/src/extensions/cgi/cgiconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidconfig.cpp
+++ b/src/extensions/cgi/cgidconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidconfig.h
+++ b/src/extensions/cgi/cgidconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidconn.cpp
+++ b/src/extensions/cgi/cgidconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidconn.h
+++ b/src/extensions/cgi/cgidconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidreq.cpp
+++ b/src/extensions/cgi/cgidreq.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidreq.h
+++ b/src/extensions/cgi/cgidreq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidworker.cpp
+++ b/src/extensions/cgi/cgidworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgidworker.h
+++ b/src/extensions/cgi/cgidworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/cgroupconn.cpp
+++ b/src/extensions/cgi/cgroupconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -22,7 +22,7 @@
 
 CGroupConn::CGroupConn()
 {
-    m_conn = NULL; 
+    m_conn = NULL;
     m_proxy = NULL;
     m_err = NULL;
     m_err_num = CERR_NO_ERROR;
@@ -63,8 +63,8 @@ int CGroupConn::load_gdb()
         //printf("Unable to load symbol: %s\n", lib);
         set_error(CERR_SYSTEM_ERROR);
         return -1;
-    }    
-    
+    }
+
     m_gio20 = dlopen(lib = (char *)"libgio-2.0.so", RTLD_LAZY);
     if (!m_gio20)
         m_gio20 = dlopen("libgio-2.0.so.0", RTLD_LAZY);
@@ -79,7 +79,7 @@ int CGroupConn::load_gdb()
     m_g_dbus_proxy_call_sync = (tg_dbus_proxy_call_sync)dlsym(m_gio20, lib = (char *)"g_dbus_proxy_call_sync");
     m_g_variant_builder_add_value = (tg_variant_builder_add_value)dlsym(m_gio20, lib = (char *)"g_variant_builder_add_value");
     m_g_variant_builder_add = (tg_variant_builder_add)dlsym(m_gio20, lib = (char *)"g_variant_builder_add");
-    
+
     if ((!m_g_bus_get_sync) ||
         (!m_g_dbus_proxy_new_sync) ||
         (!m_g_dbus_proxy_call_sync) ||
@@ -89,7 +89,7 @@ int CGroupConn::load_gdb()
         //printf("Unable to load symbol: %s\n", lib);
         set_error(CERR_SYSTEM_ERROR);
         return -1;
-    }    
+    }
 
     m_gobject20 = dlopen(lib = (char *)"libgobject-2.0.so", RTLD_LAZY);
     if (!m_gobject20)
@@ -106,7 +106,7 @@ int CGroupConn::load_gdb()
         //printf("Unable to load symbol: %s\n", lib);
         set_error(CERR_SYSTEM_ERROR);
         return -1;
-    }   
+    }
     //printf("Loaded glib\n");
     return 0;
 }
@@ -119,13 +119,13 @@ void CGroupConn::clear_err()
     if (m_g_clear_error)
         m_g_clear_error(&m_err);
     m_err_num = CERR_NO_ERROR;
-}    
-    
+}
+
 int CGroupConn::create()
 {
     if (load_gdb() == -1)
         return -1;
-    
+
     clear_err();
     m_conn = m_g_bus_get_sync(G_BUS_TYPE_SYSTEM,
                               NULL, // GCancellable
@@ -171,11 +171,11 @@ CGroupConn::~CGroupConn()
         dlclose(m_glib20);
 }
 
-   
+
 char *CGroupConn::getErrorText()
 {
     enum CGroupErrors errnum = m_err_num;
-    switch (errnum) 
+    switch (errnum)
     {
         case CERR_GDERR :
             return m_err->message;

--- a/src/extensions/cgi/cgroupconn.h
+++ b/src/extensions/cgi/cgroupconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -45,7 +45,7 @@ class CGroupUse;
 
 /**
  * @note The following definitions are taken from glib.  If you import gio/gio.h
- * you'll get these so you'll need to comment them out.  
+ * you'll get these so you'll need to comment them out.
  **/
 typedef uint32_t GQuark;
 
@@ -63,14 +63,14 @@ typedef enum
   G_BUS_TYPE_SESSION = 2
 } GBusType;
 #define G_VARIANT_TYPE_ARRAY                ((const GVariantType *) "a*")
-    
+
 
 /**
  * @note End of duplicate gio.h definitions.
  **/
 
 /**
- * @class CGroupConn  
+ * @class CGroupConn
  * @brief Every task (including subtasks) which need to access CGroups needs
  * to create an instance of this class which is passed into the CGroupUse
  * class.  Typically you create the CGroupConn and then immediately use it
@@ -83,9 +83,9 @@ class CGroupConn
 private:
     friend class CGroupUse;
     /**
-     * @enum CGroupErrors 
-     * @brief If a method (in either this class or the attached CGroupUse 
-     * class) returns -1, you must call set_error with one of these errors 
+     * @enum CGroupErrors
+     * @brief If a method (in either this class or the attached CGroupUse
+     * class) returns -1, you must call set_error with one of these errors
      * indicating the cause of the error.  Used in getErrorText.
      **/
     enum CGroupErrors {
@@ -95,18 +95,18 @@ private:
         CERR_BAD_SYSTEMD,
         CERR_SYSTEM_ERROR
     };
-    
+
     _GDBusConnection *m_conn;
     _GDBusProxy      *m_proxy;
     GError           *m_err;
     CGroupErrors      m_err_num;
-    /** 
+    /**
      * @note Stuff for glib that would be statically included if possible
      **/
     void             *m_glib20;
     void             *m_gio20;
     void             *m_gobject20;
-    typedef void (*tg_clear_error)(GError       **err);    
+    typedef void (*tg_clear_error)(GError       **err);
     tg_clear_error m_g_clear_error;
     typedef GVariant *(*tg_variant_new)(const char          *format_string,
                                         ...);
@@ -120,7 +120,7 @@ private:
                                            const GVariantType   *format_string,
                                            ...);
     tg_variant_builder_add m_g_variant_builder_add;
-    
+
     typedef GDBusConnection *(*tg_bus_get_sync)(GBusType            bus_type,
                                                 void               *cancellable,
                                                 GError            **error);
@@ -142,10 +142,10 @@ private:
                                                  void                *cancellable,
                                                  GError             **error);
     tg_dbus_proxy_call_sync m_g_dbus_proxy_call_sync;
-    
+
     typedef void *(*tg_object_unref)(void * object);
     tg_object_unref m_g_object_unref;
-    
+
     int load_gdb();
     /**
      * @note End of glib static include stuff
@@ -153,14 +153,14 @@ private:
     void set_error(enum CGroupErrors err)
     {   m_err_num = err;   }
     void clear_err();
-        
+
 public:
     CGroupConn();
     ~CGroupConn();
-    
+
     /**
      * @fn int create()
-     * @brief Call after instantiation to perform the actual creation.  
+     * @brief Call after instantiation to perform the actual creation.
      * @return 0 if success or -1 if it failed.  If it failed you can call
      * getErrorText to get the details.
      **/
@@ -169,8 +169,8 @@ public:
      * @fn char *getErrorText
      * @brief Call if a method returns -1 in either this class or the attached
      * CGroupUse class(s).
-     * @return A pointer to a text description of the problem for error 
-     * reporting or debugging.  
+     * @return A pointer to a text description of the problem for error
+     * reporting or debugging.
      **/
     char *getErrorText(); // For any functions returning -1
 
@@ -178,8 +178,8 @@ public:
      * @fn int getErrorNum
      * @brief Call if a method returns -1 in either this class or the attached
      * CGroupUse class(s).
-     * @return A number that might mean something to someone (actually one of 
-     * the enumerated types).   
+     * @return A number that might mean something to someone (actually one of
+     * the enumerated types).
      **/
     int  getErrorNum(); // For any functions returning -1
 

--- a/src/extensions/cgi/cgroupuse.cpp
+++ b/src/extensions/cgi/cgroupuse.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -32,15 +32,15 @@ CGroupUse::CGroupUse(CGroupConn *conn)
     CGroupUse::m_conn = conn;
 }
 
-    
+
 CGroupUse::~CGroupUse()
-{  
+{
 }
-    
+
 
 int CGroupUse::apply_slice()
 {
-    // The functions below are supposed to be NULL safe.  That's why I test at 
+    // The functions below are supposed to be NULL safe.  That's why I test at
     // the end for NULL.
     GVariantBuilder *properties = m_conn->m_g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
     GVariantBuilder *pids_array = m_conn->m_g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
@@ -60,7 +60,7 @@ int CGroupUse::apply_slice()
                                               "fail",
                                               properties,
                                               NULL);
-    if ((!properties) || (!pids_array) || (!pvarpid) || (!pvarparr) || 
+    if ((!properties) || (!pids_array) || (!pvarpid) || (!pvarparr) ||
         (!pvarslice) || (!parms))
     {
         // Note: These are supposed to be smart and deallocate when no longer
@@ -98,7 +98,7 @@ int CGroupUse::child_validate(pid_t pid)
 {
     char proc_file[128];
     FILE *fd;
-    
+
     snprintf(proc_file, sizeof(proc_file) - 1, "/proc/%d/cgroup", pid);
     fd = fopen(proc_file, (char *)"r");
     if (!fd)
@@ -108,7 +108,7 @@ int CGroupUse::child_validate(pid_t pid)
     char line_hoped[CUSE_LINE_LEN];
     int  found = 0;
     int  compare_len;
-    compare_len = snprintf(line_hoped, sizeof(line_hoped), 
+    compare_len = snprintf(line_hoped, sizeof(line_hoped),
                            "1:name=systemd:/user.slice/user-%u.slice/", m_uid);
     while ((!found) && (fgets(line, sizeof(line) - 1, fd)))
     {
@@ -148,7 +148,7 @@ int CGroupUse::validate()
     int rc = child_validate(pid);
     kill(pid, 9);
     int session;
-    waitpid(pid, &session, 0); 
+    waitpid(pid, &session, 0);
     return rc;
 }
 

--- a/src/extensions/cgi/cgroupuse.h
+++ b/src/extensions/cgi/cgroupuse.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -27,13 +27,13 @@
 
 /**
  * @class CGroupUse
- * @brief Create an instance of this class after you have done the fork and 
- * but are still root.  It applies the CGroup info by changing the slice the 
+ * @brief Create an instance of this class after you have done the fork and
+ * but are still root.  It applies the CGroup info by changing the slice the
  * process runs in.
  * @note This class does not do error reporting or debug logging.
  **/
 
-class CGroupUse 
+class CGroupUse
 {
 private:
     friend class CGroupConn;
@@ -42,15 +42,15 @@ private:
     int child_validate(pid_t pid);
     int m_uid;
 #define CUSE_UNIT_FORMAT "run-%u.scope"
-    
+
 public:
     /**
      * @fn CGroupUse
-     * @brief Constructor, call with a pointer to the connection. 
+     * @brief Constructor, call with a pointer to the connection.
      **/
     CGroupUse(CGroupConn *conn);
     ~CGroupUse();
-    
+
     /**
      * @fn int validate(int uid)
      * @brief Call after the connection has been created but before using the
@@ -68,13 +68,13 @@ public:
     int validate();
     /**
      * @fn int apply(int uid)
-     * @brief Call after the fork running as root.                        
+     * @brief Call after the fork running as root.
      * @param[in] uid: the UID to run the task as.  Must exist.
      * @return 0 if success or -1 if it failed.  If it failed you can call
      * getErrorText to get the details.
      **/
     int apply(int uid);
- 
+
     LS_NO_COPY_ASSIGN(CGroupUse);
 };
 

--- a/src/extensions/cgi/lscgid.cpp
+++ b/src/extensions/cgi/lscgid.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/lscgid.h
+++ b/src/extensions/cgi/lscgid.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/lscgiddef.h
+++ b/src/extensions/cgi/lscgiddef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/suexec.cpp
+++ b/src/extensions/cgi/suexec.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/suexec.h
+++ b/src/extensions/cgi/suexec.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/use_bwrap.c
+++ b/src/extensions/cgi/use_bwrap.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/cgi/use_bwrap.h
+++ b/src/extensions/cgi/use_bwrap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/detached.h
+++ b/src/extensions/detached.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extconn.cpp
+++ b/src/extensions/extconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extconn.h
+++ b/src/extensions/extconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extrequest.cpp
+++ b/src/extensions/extrequest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extrequest.h
+++ b/src/extensions/extrequest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extworker.cpp
+++ b/src/extensions/extworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extworker.h
+++ b/src/extensions/extworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extworkerconfig.cpp
+++ b/src/extensions/extworkerconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/extworkerconfig.h
+++ b/src/extensions/extworkerconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiapp.cpp
+++ b/src/extensions/fcgi/fcgiapp.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiapp.h
+++ b/src/extensions/fcgi/fcgiapp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiappconfig.cpp
+++ b/src/extensions/fcgi/fcgiappconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiappconfig.h
+++ b/src/extensions/fcgi/fcgiappconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiconnection.cpp
+++ b/src/extensions/fcgi/fcgiconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgiconnection.h
+++ b/src/extensions/fcgi/fcgiconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgidef.h
+++ b/src/extensions/fcgi/fcgidef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgienv.cpp
+++ b/src/extensions/fcgi/fcgienv.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgienv.h
+++ b/src/extensions/fcgi/fcgienv.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcginamevaluepair.cpp
+++ b/src/extensions/fcgi/fcginamevaluepair.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcginamevaluepair.h
+++ b/src/extensions/fcgi/fcginamevaluepair.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgirecord.cpp
+++ b/src/extensions/fcgi/fcgirecord.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgirecord.h
+++ b/src/extensions/fcgi/fcgirecord.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgireqlist.cpp
+++ b/src/extensions/fcgi/fcgireqlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgireqlist.h
+++ b/src/extensions/fcgi/fcgireqlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgirequest.cpp
+++ b/src/extensions/fcgi/fcgirequest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgirequest.h
+++ b/src/extensions/fcgi/fcgirequest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgistarter.cpp
+++ b/src/extensions/fcgi/fcgistarter.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/fcgistarter.h
+++ b/src/extensions/fcgi/fcgistarter.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/samplefcgiextconn.cpp
+++ b/src/extensions/fcgi/samplefcgiextconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/fcgi/samplefcgiextconn.h
+++ b/src/extensions/fcgi/samplefcgiextconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/httpextprocessor.cpp
+++ b/src/extensions/httpextprocessor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/httpextprocessor.h
+++ b/src/extensions/httpextprocessor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/iprocessortimer.cpp
+++ b/src/extensions/iprocessortimer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/iprocessortimer.h
+++ b/src/extensions/iprocessortimer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jconn.cpp
+++ b/src/extensions/jk/jconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jconn.h
+++ b/src/extensions/jk/jconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jkajp13.cpp
+++ b/src/extensions/jk/jkajp13.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -285,7 +285,7 @@ int JkAjp13::buildReq(HttpSession *pSession, char *&p, char *pEnd)
         *p++ = AJP_A_QUERY_STRING;
         appendString(p, pAttr, n);
     }
-    
+
     HioCrypto *pCrypto = pSession->getCrypto();
     if (pCrypto)
     {
@@ -299,21 +299,21 @@ int JkAjp13::buildReq(HttpSession *pSession, char *&p, char *pEnd)
             *p++ = AJP_A_SSL_SESSION;
             appendString(p, pVal, n);
         }
-    
+
         n = pCrypto->getEnv(HioCrypto::CIPHER, pVal, sizeof(buf));
         if (pEnd2 - p < n)
             return LS_FAIL;
         *p++ = AJP_A_SSL_CIPHER;
         appendString(p, pVal, n);
-    
-    
+
+
         pVal = buf;
         n = pCrypto->getEnv(HioCrypto::CIPHER_USEKEYSIZE, pVal, sizeof(buf));
         if (pEnd2 - p < n)
             return LS_FAIL;
         *p++ = AJP_A_SSL_KEY_SIZE;
         appendString(p, pVal, n);
-  
+
         X509 *pClientCert = pCrypto->getPeerCertificate();
         if (pClientCert)
         {

--- a/src/extensions/jk/jkajp13.h
+++ b/src/extensions/jk/jkajp13.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jworker.cpp
+++ b/src/extensions/jk/jworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jworker.h
+++ b/src/extensions/jk/jworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jworkerconfig.cpp
+++ b/src/extensions/jk/jworkerconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/jk/jworkerconfig.h
+++ b/src/extensions/jk/jworkerconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/l4conn.cpp
+++ b/src/extensions/l4conn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/l4conn.h
+++ b/src/extensions/l4conn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/loadbalancer.cpp
+++ b/src/extensions/loadbalancer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/loadbalancer.h
+++ b/src/extensions/loadbalancer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/localworker.cpp
+++ b/src/extensions/localworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/localworker.h
+++ b/src/extensions/localworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -68,14 +68,14 @@ class LocalWorker : public ExtWorker
     RestartMarker      *m_pRestartMarker;
     DetachedProcess_t  *m_pDetached;
 
-    
+
     void        moveToStopList();
 public:
     static time_t       s_tmRestartPhp;
-    
+
     explicit LocalWorker(int type);
 
-    
+
     ~LocalWorker();
 
     LocalWorkerConfig &getConfig() const;
@@ -102,12 +102,12 @@ public:
     int tryRestart();
     int restart();
     int addNewProcess();
-    
+
     virtual void onTimer();
 
     int startWorker();
     void setRestartMarker(const char* path, int reset_me_path_pos);
-    
+
     static int workerExec(LocalWorkerConfig &config, int fd);
     static void configRlimit(RLimits *pRLimits, const XmlNode *pNode);
 
@@ -118,7 +118,7 @@ public:
     bool detectBinaryChange();
     int processPid(int pid, const char * path);
 
-    
+
     bool loadDetachedPid(int fd, DetachedPidInfo_t *detached_pid);
     void saveDetachedPid(int fd, DetachedPidInfo_t *detached_pid,
                                     const char *path);
@@ -135,9 +135,9 @@ public:
     //             can be `-HTTP_Status_Code`
 
     int startDetachedWorker(int force);
-    
-    
-    
+
+
+
     LS_NO_COPY_ASSIGN(LocalWorker);
 };
 

--- a/src/extensions/localworkerconfig.cpp
+++ b/src/extensions/localworkerconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/localworkerconfig.h
+++ b/src/extensions/localworkerconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapiconfig.cpp
+++ b/src/extensions/lsapi/lsapiconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapiconfig.h
+++ b/src/extensions/lsapi/lsapiconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapiconn.cpp
+++ b/src/extensions/lsapi/lsapiconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapiconn.h
+++ b/src/extensions/lsapi/lsapiconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapidef.h
+++ b/src/extensions/lsapi/lsapidef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapireq.cpp
+++ b/src/extensions/lsapi/lsapireq.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapireq.h
+++ b/src/extensions/lsapi/lsapireq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/lsapi/lsapiworker.cpp
+++ b/src/extensions/lsapi/lsapiworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -51,7 +51,7 @@ int LsapiWorker::startEx()
         {
             ret = startDetachedWorker(0);
         }
-        else            
+        else
             ret = startWorker();
     }
     return ret;

--- a/src/extensions/lsapi/lsapiworker.h
+++ b/src/extensions/lsapi/lsapiworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/pidlist.cpp
+++ b/src/extensions/pidlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/pidlist.h
+++ b/src/extensions/pidlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyconfig.cpp
+++ b/src/extensions/proxy/proxyconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyconfig.h
+++ b/src/extensions/proxy/proxyconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyconn.cpp
+++ b/src/extensions/proxy/proxyconn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyconn.h
+++ b/src/extensions/proxy/proxyconn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyworker.cpp
+++ b/src/extensions/proxy/proxyworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/proxy/proxyworker.h
+++ b/src/extensions/proxy/proxyworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/registry/appconfig.cpp
+++ b/src/extensions/registry/appconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/registry/appconfig.h
+++ b/src/extensions/registry/appconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/registry/extappregistry.cpp
+++ b/src/extensions/registry/extappregistry.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/extensions/registry/extappregistry.h
+++ b/src/extensions/registry/extappregistry.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -92,7 +92,7 @@ public:
     static void shutdown();
     static int generateRTReport(int fd);
     static int hasUri(const char *uri);
-    
+
     static void getUniAppUri(const char *app_uri, char *dst, int dst_len, int uid, int loop = 0);
     static int configVhostOwnPhp(HttpVHost *pVHost);
     static ExtWorker *configExtApp(const XmlNode *pNode, const HttpVHost *pVHost);
@@ -101,7 +101,7 @@ public:
     static int configExtApps(const XmlNode *pRoot, const HttpVHost *pVHost);
     static RLimits *getRLimits()    {   return s_pRLimits;  }
     static void setRLimits(RLimits *pRLimits)   {   s_pRLimits = pRLimits;  }
-    
+
     LS_NO_COPY_ASSIGN(ExtAppRegistry);
 };
 
@@ -118,8 +118,8 @@ public:
     static int markToStop(pid_t pid, int kill_type);
     static void sendKillCmdToWatchdog(pid_t pid, int kill_type, long lastmod);
     static void addMarkToStop(pid_t pid, int kill_type, long lastmod);
-    
-    
+
+
     LS_NO_COPY_ASSIGN(PidRegistry);
 };
 

--- a/src/http/accesscache.cpp
+++ b/src/http/accesscache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/accesscache.h
+++ b/src/http/accesscache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/accesslog.cpp
+++ b/src/http/accesslog.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/accesslog.h
+++ b/src/http/accesslog.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/authuser.cpp
+++ b/src/http/authuser.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/authuser.h
+++ b/src/http/authuser.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/awstats.cpp
+++ b/src/http/awstats.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/awstats.h
+++ b/src/http/awstats.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/cacheelement.cpp
+++ b/src/http/cacheelement.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/cacheelement.h
+++ b/src/http/cacheelement.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/chunkinputstream.cpp
+++ b/src/http/chunkinputstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/chunkinputstream.h
+++ b/src/http/chunkinputstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/chunkoutputstream.cpp
+++ b/src/http/chunkoutputstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/chunkoutputstream.h
+++ b/src/http/chunkoutputstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/clientcache.cpp
+++ b/src/http/clientcache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/clientcache.h
+++ b/src/http/clientcache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/clientinfo.cpp
+++ b/src/http/clientinfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/clientinfo.h
+++ b/src/http/clientinfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/connlimitctrl.cpp
+++ b/src/http/connlimitctrl.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/connlimitctrl.h
+++ b/src/http/connlimitctrl.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contextlist.cpp
+++ b/src/http/contextlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contextlist.h
+++ b/src/http/contextlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contextnode.cpp
+++ b/src/http/contextnode.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contextnode.h
+++ b/src/http/contextnode.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contexttree.cpp
+++ b/src/http/contexttree.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/contexttree.h
+++ b/src/http/contexttree.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/denieddir.cpp
+++ b/src/http/denieddir.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/denieddir.h
+++ b/src/http/denieddir.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/eventdispatcher.cpp
+++ b/src/http/eventdispatcher.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/eventdispatcher.h
+++ b/src/http/eventdispatcher.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/expiresctrl.cpp
+++ b/src/http/expiresctrl.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/expiresctrl.h
+++ b/src/http/expiresctrl.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/handlerfactory.cpp
+++ b/src/http/handlerfactory.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/handlerfactory.h
+++ b/src/http/handlerfactory.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/handlertype.cpp
+++ b/src/http/handlertype.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/handlertype.h
+++ b/src/http/handlertype.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiochainstream.cpp
+++ b/src/http/hiochainstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiochainstream.h
+++ b/src/http/hiochainstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiohandlerfactory.cpp
+++ b/src/http/hiohandlerfactory.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiohandlerfactory.h
+++ b/src/http/hiohandlerfactory.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiostream.cpp
+++ b/src/http/hiostream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hiostream.h
+++ b/src/http/hiostream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hotlinkctrl.cpp
+++ b/src/http/hotlinkctrl.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/hotlinkctrl.h
+++ b/src/http/hotlinkctrl.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/htauth.cpp
+++ b/src/http/htauth.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/htauth.h
+++ b/src/http/htauth.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/htpasswd.cpp
+++ b/src/http/htpasswd.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/htpasswd.h
+++ b/src/http/htpasswd.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpaiosendfile.cpp
+++ b/src/http/httpaiosendfile.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpaiosendfile.h
+++ b/src/http/httpaiosendfile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcache.cpp
+++ b/src/http/httpcache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcache.h
+++ b/src/http/httpcache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcgitool.cpp
+++ b/src/http/httpcgitool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcgitool.h
+++ b/src/http/httpcgitool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcontext.cpp
+++ b/src/http/httpcontext.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpcontext.h
+++ b/src/http/httpcontext.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpdefs.h
+++ b/src/http/httpdefs.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpextconnector.cpp
+++ b/src/http/httpextconnector.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpextconnector.h
+++ b/src/http/httpextconnector.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httphandler.cpp
+++ b/src/http/httphandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httphandler.h
+++ b/src/http/httphandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpheader.cpp
+++ b/src/http/httpheader.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpheader.h
+++ b/src/http/httpheader.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplistener.cpp
+++ b/src/http/httplistener.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplistener.h
+++ b/src/http/httplistener.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplistenerlist.cpp
+++ b/src/http/httplistenerlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -301,8 +301,8 @@ void HttpListenerList::recvListeners()
                 pListener->assign(fd, pAddr);
                 push_back(pListener);
                 sort(s_compare);
-                
-                LS_NOTICE("Recv listener %s, copy fd %d to %d.", 
+
+                LS_NOTICE("Recv listener %s, copy fd %d to %d.",
                       pListener->getAddrStr(),
                       startfd, fd);
             }
@@ -374,7 +374,7 @@ int HttpListenerList::saveInUseListnersTo(HttpListenerList &rhs)
     int add = 0;
     iterator iter;
     for (iter = begin(); iter != end();)
-    {   
+    {
         (*iter)->stop();
         if ((*iter)->getVHostMap()->getRef() <= 0)
         {

--- a/src/http/httplistenerlist.h
+++ b/src/http/httplistenerlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplog.cpp
+++ b/src/http/httplog.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplog.h
+++ b/src/http/httplog.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplogsource.cpp
+++ b/src/http/httplogsource.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httplogsource.h
+++ b/src/http/httplogsource.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpmethod.cpp
+++ b/src/http/httpmethod.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpmethod.h
+++ b/src/http/httpmethod.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpmime.cpp
+++ b/src/http/httpmime.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpmime.h
+++ b/src/http/httpmime.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httprange.cpp
+++ b/src/http/httprange.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httprange.h
+++ b/src/http/httprange.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpreq.cpp
+++ b/src/http/httpreq.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpreq.h
+++ b/src/http/httpreq.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpresourcemanager.cpp
+++ b/src/http/httpresourcemanager.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -102,13 +102,13 @@ void HttpResourceManager::onTimer()
 MMapVMemBuf *HttpResourceManager::getVMemBuf()
 {   return new MMapVMemBuf();           }
 
-    
+
 void HttpResourceManager::recycle(VMemBuf *pBuf)
 {   delete pBuf;                        }
-    
 
 
-      
+
+
 HttpSession *HttpResourceManager::getConnection()
 {
     return new HttpSession();

--- a/src/http/httpresourcemanager.h
+++ b/src/http/httpresourcemanager.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpresp.cpp
+++ b/src/http/httpresp.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpresp.h
+++ b/src/http/httpresp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httprespheaders.cpp
+++ b/src/http/httprespheaders.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httprespheaders.h
+++ b/src/http/httprespheaders.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpserverconfig.cpp
+++ b/src/http/httpserverconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpserverconfig.h
+++ b/src/http/httpserverconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpserverversion.cpp
+++ b/src/http/httpserverversion.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpserverversion.h
+++ b/src/http/httpserverversion.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpsession.cpp
+++ b/src/http/httpsession.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpsession.h
+++ b/src/http/httpsession.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpsessionmt.h
+++ b/src/http/httpsessionmt.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpsignals.cpp
+++ b/src/http/httpsignals.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpsignals.h
+++ b/src/http/httpsignals.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstats.cpp
+++ b/src/http/httpstats.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstats.h
+++ b/src/http/httpstats.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstatuscode.cpp
+++ b/src/http/httpstatuscode.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstatuscode.h
+++ b/src/http/httpstatuscode.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstatusline.cpp
+++ b/src/http/httpstatusline.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpstatusline.h
+++ b/src/http/httpstatusline.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpver.cpp
+++ b/src/http/httpver.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpver.h
+++ b/src/http/httpver.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpvhost.cpp
+++ b/src/http/httpvhost.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpvhost.h
+++ b/src/http/httpvhost.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpvhostlist.cpp
+++ b/src/http/httpvhostlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/httpvhostlist.h
+++ b/src/http/httpvhostlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/ip2geo.h
+++ b/src/http/ip2geo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -36,7 +36,7 @@ public:
     virtual ~GeoInfo() { };
     virtual const char *getGeoEnv(const char *pEnvName) = 0;
     virtual int addGeoEnv(IEnv *pEnv) = 0;
-    
+
 private:
     LS_NO_COPY_ASSIGN(GeoInfo);
 };
@@ -47,15 +47,15 @@ public:
     // Call the constructor AFTER having configured everything
     Ip2Geo() { }
     virtual ~Ip2Geo() { };
-    
+
     virtual int config(const XmlNodeList *pList) = 0;
 
     // Called only after config and setEnv
     // Note that GeoInfo is allocated and returned from a successful lookup
     virtual GeoInfo *lookUp(uint32_t addr) = 0;
     virtual GeoInfo *lookUpV6(in6_addr addr) = 0;
-    
-private:    
+
+private:
     LS_NO_COPY_ASSIGN(Ip2Geo);
 };
 

--- a/src/http/iptogeo2.cpp
+++ b/src/http/iptogeo2.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -48,7 +48,7 @@ struct  GeoIpData2::env_found_s
     const char *m_value; // Variable value string
 };
 typedef struct GeoIpData2::env_found_s env_found_t;
-    
+
 // An array that always matches the m_ndbs in IpToGeo2;
 struct GeoIpData2::db_found_s
 {
@@ -75,13 +75,13 @@ typedef struct IpToGeo2::dbs_s dbs_t;
 
 // I only have samples of the ASN, City and Country databases.  We can add
 // more as we get more samples.
-IpToGeo2::env_t s_env_ASN[] = 
+IpToGeo2::env_t s_env_ASN[] =
 {
     { "GEOIP_ORGANIZATION", "/autonomous_system_organization" },
     { "GEOIP_ISP", "/autonomous_system_number" },
 };
 
-IpToGeo2::env_t s_env_City[] = 
+IpToGeo2::env_t s_env_City[] =
 {
     { "GEOIP_COUNTRY_CODE", "/country/iso_code" },
     { "GEOIP_COUNTRY_NAME", "/country/names/en" },
@@ -97,7 +97,7 @@ IpToGeo2::env_t s_env_City[] =
     { "GEOIP_CITY", "/city/names/en" },
 };
 
-IpToGeo2::env_t s_env_Country[] = 
+IpToGeo2::env_t s_env_Country[] =
 {
     { "GEOIP_COUNTRY_CODE", "/country/iso_code" },
     { "GEOIP_COUNTRY_NAME", "/country/names/en" },
@@ -107,23 +107,23 @@ IpToGeo2::env_t s_env_Country[] =
 
 IpToGeo2::dbs_t s_db_default[] =
 {
-    { 0, 
-      "GeoLite2-ASN.mmdb", 
-      "ASN_DB", 
-      NULL, 
-      (int)(sizeof(s_env_ASN) / sizeof(IpToGeo2::env_t)), 
+    { 0,
+      "GeoLite2-ASN.mmdb",
+      "ASN_DB",
+      NULL,
+      (int)(sizeof(s_env_ASN) / sizeof(IpToGeo2::env_t)),
       s_env_ASN },
-    { 0, 
-      "GeoLite2-Country.mmdb", 
-      "COUNTRY_DB", 
-      NULL, 
-      (int)(sizeof(s_env_Country) / sizeof(IpToGeo2::env_t)), 
+    { 0,
+      "GeoLite2-Country.mmdb",
+      "COUNTRY_DB",
+      NULL,
+      (int)(sizeof(s_env_Country) / sizeof(IpToGeo2::env_t)),
       s_env_Country },
-    { 0, 
-      "GeoLite2-City.mmdb", 
-      "CITY_DB", 
-      NULL, 
-      (int)(sizeof(s_env_City) / sizeof(IpToGeo2::env_t)), 
+    { 0,
+      "GeoLite2-City.mmdb",
+      "CITY_DB",
+      NULL,
+      (int)(sizeof(s_env_City) / sizeof(IpToGeo2::env_t)),
       s_env_City }
 };
 
@@ -176,17 +176,17 @@ char *GeoIpData2::strutf8(MMDB_entry_data_s *entry_data, char *key)
 {
     if (entry_data->data_size >= (MAX_KEY_LENGTH - 1))
     {
-        memcpy(key, entry_data->utf8_string, 
+        memcpy(key, entry_data->utf8_string,
                (MAX_KEY_LENGTH - 1));
         key[(MAX_KEY_LENGTH - 1)] = 0;
     }
     else
     {
-        memcpy(key, entry_data->utf8_string, 
+        memcpy(key, entry_data->utf8_string,
                entry_data->data_size);
         key[entry_data->data_size] = 0;
     }
-    return key;    
+    return key;
 }
 
 
@@ -201,7 +201,7 @@ char *GeoIpData2::strint(MMDB_entry_data_s *entry_data, char *key)
             fmt = "%lu";
             if (entry_data->type == MMDB_DATA_TYPE_UINT16)
                 i = entry_data->uint16;
-            else 
+            else
                 i = entry_data->uint32;
             break;
         case MMDB_DATA_TYPE_INT32:
@@ -221,7 +221,7 @@ char *GeoIpData2::strint(MMDB_entry_data_s *entry_data, char *key)
 
 char *GeoIpData2::strdouble(MMDB_entry_data_s *entry_data, char *key)
 {
-    snprintf(key, MAX_KEY_LENGTH - 1, "%7.5f", 
+    snprintf(key, MAX_KEY_LENGTH - 1, "%7.5f",
              entry_data->double_value);
     return(key);
 }
@@ -300,7 +300,7 @@ char *GeoIpData2::extract_simple_data(MMDB_entry_data_s *data)
     if ((data->type == MMDB_DATA_TYPE_INT32) ||
         (data->type == MMDB_DATA_TYPE_UINT16) ||
         (data->type == MMDB_DATA_TYPE_UINT32) ||
-        (data->type == MMDB_DATA_TYPE_UINT64)) 
+        (data->type == MMDB_DATA_TYPE_UINT64))
         return extractInt(data);
     if (data->type == MMDB_DATA_TYPE_BOOLEAN)
         return extractBoolean(data);
@@ -318,7 +318,7 @@ int GeoIpData2::process_map_key(int db, char *key,
     {
         IpToGeo2::env_t const *env = &m_IpToGeo2->m_dbs[db].m_env[i];
         env_found_t *env_found = &db_found->m_env_found[i];
-        
+
         if (!(strcasecmp(key, env->m_key)))
         {
             LS_DBG("[GEO] Found key %s, env: %s\n", key, env->m_var);
@@ -338,9 +338,9 @@ int GeoIpData2::process_map_key(int db, char *key,
                          env->m_var);
                 return -1;
             }
-            else 
+            else
             {
-                LS_DBG("[GEO] Env found: db #%d %s=%s=%s\n", db, key, env->m_var, 
+                LS_DBG("[GEO] Env found: db #%d %s=%s=%s\n", db, key, env->m_var,
                        env_found->m_value);
                 break;
             }
@@ -348,8 +348,8 @@ int GeoIpData2::process_map_key(int db, char *key,
     }
     return 0;
 }
-    
-    
+
+
 int GeoIpData2::process_array_entry(int db, char *key,
                                     MMDB_entry_data_s *entry_data)
 {
@@ -360,7 +360,7 @@ int GeoIpData2::process_array_entry(int db, char *key,
     {
         IpToGeo2::env_t const *env = &m_IpToGeo2->m_dbs[db].m_env[i];
         env_found_t *env_found = &db_found->m_env_found[i];
-        
+
         if (!(strcasecmp(key, env->m_key)))
         {
             env_found->m_value = extract_simple_data(entry_data);
@@ -372,7 +372,7 @@ int GeoIpData2::process_array_entry(int db, char *key,
             }
             else
             {
-                LS_DBG("[GEO] Env found: db #%d %s=%s=%s\n", db, key, env->m_var, 
+                LS_DBG("[GEO] Env found: db #%d %s=%s=%s\n", db, key, env->m_var,
                        env_found->m_value);
                 break;
             }
@@ -380,21 +380,21 @@ int GeoIpData2::process_array_entry(int db, char *key,
     }
     return 0;
 }
-    
-    
+
+
 int GeoIpData2::check_entry_data_list(
     int db,
-    MMDB_entry_data_list_s *entry_data_list, 
-    MMDB_entry_data_list_s **entry_data_list_next, char *key_full) 
+    MMDB_entry_data_list_s *entry_data_list,
+    MMDB_entry_data_list_s **entry_data_list_next, char *key_full)
 {
     LS_DBG("[GEO] check_entry_data_list: key: %s\n", key_full ? key_full : "");
-    if (!entry_data_list) 
+    if (!entry_data_list)
     {
         LS_ERROR("[GEO] NULL entry data list while interpreting GEO result\n");
         return -1;
     }
     uint32_t initial_type = entry_data_list->entry_data.type;
-    LS_DBG("[GEO] initial type: %d\n", initial_type);        
+    LS_DBG("[GEO] initial type: %d\n", initial_type);
     int ret;
     // Handle the aggregate types separately.
     if (initial_type == MMDB_DATA_TYPE_MAP)
@@ -403,20 +403,20 @@ int GeoIpData2::check_entry_data_list(
         uint32_t initial_count = count;
         LS_DBG("[GEO] Map count: %d\n", count);
         entry_data_list = entry_data_list->next;
-        while ((entry_data_list) && (count)) 
+        while ((entry_data_list) && (count))
         {
             count--;
             if (MMDB_DATA_TYPE_UTF8_STRING != entry_data_list->entry_data.type) {
-                LS_ERROR("[GEO] Expected a string type in a map (got %d)\n", 
+                LS_ERROR("[GEO] Expected a string type in a map (got %d)\n",
                          entry_data_list->entry_data.type);
                 return -1;
             }
             char key[MAX_KEY_LENGTH];
             char key_child[MAX_KEY_LENGTH];
             strutf8(&entry_data_list->entry_data, key);
-            snprintf(key_child, sizeof(key_child), "%s/%s", 
+            snprintf(key_child, sizeof(key_child), "%s/%s",
                      key_full ? key_full : "", key);
-            LS_DBG("[GEO] Map[%d of %d] key_child: %s\n", initial_count - count, 
+            LS_DBG("[GEO] Map[%d of %d] key_child: %s\n", initial_count - count,
                    initial_count, key_child);
             if (process_map_key(db, key_child, entry_data_list) == -1)
                 return -1;
@@ -434,25 +434,25 @@ int GeoIpData2::check_entry_data_list(
     {
         uint32_t count = entry_data_list->entry_data.data_size;
         /* A customer found a bug where there might be multiple array elements
-         * so we need to be able to deal with an array element (as is 
+         * so we need to be able to deal with an array element (as is
          * documented.  */
         if (key_full == NULL)
             key_full = (char *)"0";
         int index = 0;
-        entry_data_list = entry_data_list->next; 
+        entry_data_list = entry_data_list->next;
         LS_DBG("[GEO] Array: Count: %d\n", count);
         while (count && entry_data_list)
-        { 
+        {
             char key_child[MAX_KEY_LENGTH];
 
-            snprintf(key_child, sizeof(key_child), "%s/%u", 
+            snprintf(key_child, sizeof(key_child), "%s/%u",
                      key_full ? key_full : "", index);
             LS_DBG("[GEO] Array[%d]:\n", index);
             if (simple_data_type(&entry_data_list->entry_data))
             {
-                LS_DBG("[GEO] Array: SIMPLE, type: %d\n", 
+                LS_DBG("[GEO] Array: SIMPLE, type: %d\n",
                        entry_data_list->entry_data.type);
-                if (process_array_entry(db, key_child, 
+                if (process_array_entry(db, key_child,
                                         &entry_data_list->entry_data) == -1)
                     return -1;
                 entry_data_list = entry_data_list->next;
@@ -462,7 +462,7 @@ int GeoIpData2::check_entry_data_list(
                 LS_DBG("[GEO] Array: Container, type: %d\n",
                        entry_data_list->entry_data.type);
                 ret = check_entry_data_list(db, entry_data_list,
-                                            &entry_data_list, 
+                                            &entry_data_list,
                                             key_child);
                 if (ret)
                     return ret;
@@ -473,12 +473,12 @@ int GeoIpData2::check_entry_data_list(
         (*entry_data_list_next) = entry_data_list;
         return 0; // advanced through recursion
     }
-        
+
     if (entry_data_list)
         entry_data_list = entry_data_list->next;
-        
+
     (*entry_data_list_next) = entry_data_list;
- 
+
     return 0;
 }
 
@@ -486,7 +486,7 @@ int GeoIpData2::check_entry_data_list(
 int GeoIpData2::parseEnv()
 {
     LS_DBG("[GEO] parseEnv\n");
-    
+
     m_tried_parse_env = 1;
     for (int i = 0; i < m_IpToGeo2->m_ndbs; ++i)
     {
@@ -499,19 +499,19 @@ int GeoIpData2::parseEnv()
             {
                 LS_ERROR("[GEO] Insufficient memory to create DB env\n");
                 return LS_FAIL;
-            }    
+            }
             memset(m_db_found[i].m_env_found,0,size);
         }
         MMDB_entry_data_list_s *list = m_db_found[i].m_list;
         while (list)
-        {   
+        {
 
             if (check_entry_data_list(i, list, &list, NULL))
             {
                 LS_DBG("[GEO] Error in check_entry_data_list\n");
                 break;
             }
-        }   
+        }
         if (m_db_found[i].m_list)
         {
             MMDB_free_entry_data_list(m_db_found[i].m_list);
@@ -526,7 +526,7 @@ int GeoIpData2::parseEnv()
 const char* GeoIpData2::getGeoEnv(const char* pEnvName)
 {
     LS_DBG("[GEO] getGeoEnv: %s\n", pEnvName);
-    if (!m_IpToGeo2) 
+    if (!m_IpToGeo2)
     {
         LS_ERROR("[GEO] Attempt to get GeoEnv without first doing lookup\n");
         return NULL;
@@ -559,7 +559,7 @@ const char* GeoIpData2::getGeoEnv(const char* pEnvName)
                         LS_DBG("[GEO] NULL value so keep looking (db #%d)\n", i);
                         break; // out of envs to next db
                     }
-                    else 
+                    else
                         return m_db_found[i].m_env_found[e].m_value;
                 }
         }
@@ -572,7 +572,7 @@ int GeoIpData2::addGeoEnv(IEnv *pEnv)
 {
     int count = 0;
     LS_DBG("[GEO] addGeoEnv\n");
-    if (!m_IpToGeo2) 
+    if (!m_IpToGeo2)
     {
         LS_ERROR("[GEO] Attempt to add GeoEnv without first doing lookup\n");
         return -1;
@@ -597,7 +597,7 @@ int GeoIpData2::addGeoEnv(IEnv *pEnv)
         {
             if (m_db_found[db].m_env_found[env].m_value)
             {
-                LS_DBG("[GEO] Found env %s=%s\n", 
+                LS_DBG("[GEO] Found env %s=%s\n",
                        m_IpToGeo2->m_dbs[db].m_env[env].m_var,
                        m_db_found[db].m_env_found[env].m_value);
                 pEnv->add(m_IpToGeo2->m_dbs[db].m_env[env].m_var,
@@ -706,17 +706,17 @@ int IpToGeo2::loadGeoIpDbFile(const char *pFile, const char *pDbLogical)
         return LS_FAIL; // Free it all in the destructor
     }
     ret = MMDB_open(pFile, 0, m_dbs[m_ndbs].m_mmdb);
-    if (ret != 0) 
+    if (ret != 0)
     {
-        LS_ERROR("[GEO] Error opening GeoIP2 DB file: %s: %s\n", pFile, 
+        LS_ERROR("[GEO] Error opening GeoIP2 DB file: %s: %s\n", pFile,
                  MMDB_strerror(ret));
         return LS_FAIL;
     }
     m_dbs[m_ndbs].m_open = 1;
-    LS_DBG("[GEO] Geo file: %s now open, size: %ld\n", 
+    LS_DBG("[GEO] Geo file: %s now open, size: %ld\n",
            m_dbs[m_ndbs].m_mmdb->filename, m_dbs[m_ndbs].m_mmdb->file_size);
     m_ndbs++;
-    
+
     return 0;
 }
 
@@ -767,7 +767,7 @@ int IpToGeo2::testGeoIpDbFile(const char *pFile)
             return 0;
     LS_ERROR("[GEO] GeoIP DB file test failed: '%s'.  ret: %d\n", pFile, ret);
 
-    //    LS_ERROR("[GEO] GeoIP DB file test failed: '%s'.  Exited: %d, Status: %d\n", 
+    //    LS_ERROR("[GEO] GeoIP DB file test failed: '%s'.  Exited: %d, Status: %d\n",
     //             pFile, WIFEXITED(status), WEXITSTATUS(status));
     //}
     return -1;
@@ -810,8 +810,8 @@ const char *IpToGeo2::getDefaultLogicalName(const char *fileName)
     for (int i = 0; i < (int)(sizeof(s_db_default) / sizeof(dbs_t)); ++i)
     {
         int defDbLen = strlen(s_db_default[i].m_file);
-        if ((dblen > defDbLen) && 
-            (!(strcmp(s_db_default[i].m_file, 
+        if ((dblen > defDbLen) &&
+            (!(strcmp(s_db_default[i].m_file,
                       &fileName[dblen - defDbLen]))))
         {
             return s_db_default[i].m_logical;
@@ -824,7 +824,7 @@ const char *IpToGeo2::getDefaultLogicalName(const char *fileName)
 /**
  * config: With XmlNodeList
  * "GeoIP DB": Allows you a user to specify a NEW DB name in the OLD form.
- *             User interface nests environment variables within the XML 
+ *             User interface nests environment variables within the XML
  *             definition.  Process the name, then the nested stuff and then
  *             do the defaults so that they will NOT overwrite the user's
  *             specifications.
@@ -871,8 +871,8 @@ int IpToGeo2::config(const XmlNodeList *pList)
                 XmlNodeList children;
                 p->getAllChildren(children);
                 XmlNodeList::const_iterator iterChild;
-                
-                for (iterChild = children.begin(); iterChild != children.end(); 
+
+                for (iterChild = children.begin(); iterChild != children.end();
                      ++iterChild)
                 {
                     XmlNode *parm = *iterChild;
@@ -881,7 +881,7 @@ int IpToGeo2::config(const XmlNodeList *pList)
                     if (!strcasecmp(parm->getName(), "geoipdbname"))
                     {
                         logicalName = parm->getValue();
-                        LS_DBG_M("[GEO] geoipdb found logical name: %s\n", 
+                        LS_DBG_M("[GEO] geoipdb found logical name: %s\n",
                                  logicalName);
                     }
                     else if (!strcasecmp(parm->getName(),"maxminddbenv"))
@@ -891,7 +891,7 @@ int IpToGeo2::config(const XmlNodeList *pList)
                     }
                 }
             }
-            if (!logicalName) 
+            if (!logicalName)
             {
                 // Use a default logical name?
                 if (!(logicalName = getDefaultLogicalName(pFile)))
@@ -906,8 +906,8 @@ int IpToGeo2::config(const XmlNodeList *pList)
                 XmlNodeList children;
                 p->getAllChildren(children);
                 XmlNodeList::const_iterator iterChild;
-                
-                for (iterChild = children.begin(); iterChild != children.end(); 
+
+                for (iterChild = children.begin(); iterChild != children.end();
                      ++iterChild)
                 {
                     XmlNode *parm = *iterChild;
@@ -943,7 +943,7 @@ int IpToGeo2::config(const XmlNodeList *pList)
 int IpToGeo2::configSetFile(const char *pAliasFileName)
 {
     /**
-     * AliasFileName format is everything defined for 'MaxMindDBFile' AFTER 
+     * AliasFileName format is everything defined for 'MaxMindDBFile' AFTER
      * that keyword: <whitespace><db_logical><whitespace><file_name>
      **/
     const char *env_title = "MaxMindDBFile";
@@ -952,7 +952,7 @@ int IpToGeo2::configSetFile(const char *pAliasFileName)
     char alias[MAX_PATH_LEN];
     const char *whitespace = " \t=";
     const char *pAlias;
-    /* skip whitespace.  */    
+    /* skip whitespace.  */
     i = strspn(pAliasFileName,whitespace);
     pAliasFileName += i;
     if (!*pAliasFileName)
@@ -1004,9 +1004,9 @@ int IpToGeo2::configSetFile(const char *pAliasFileName)
 }
 
 
-int IpToGeo2::parseEnvLine(const char *pEnvAliasMap, 
+int IpToGeo2::parseEnvLine(const char *pEnvAliasMap,
                            char *variable, int var_len,
-                           char *database, int database_len, 
+                           char *database, int database_len,
                            char *map, int map_len)
 {
     /**
@@ -1021,8 +1021,8 @@ int IpToGeo2::parseEnvLine(const char *pEnvAliasMap,
     const char *whitespace = " \t=";
     const char *pMap;
     LS_DBG("[GEO] parseEnvLine: %s\n", pEnvAliasMap);
-    
-    /* skip whitespace.  */    
+
+    /* skip whitespace.  */
     i = strspn(pEnvAliasMap,whitespace);
     pEnvAliasMap += i;
     if (!*pEnvAliasMap)
@@ -1062,14 +1062,14 @@ int IpToGeo2::parseEnvLine(const char *pEnvAliasMap,
     // Mapping is two components <database>/<heirarchical-map>
     if (*pMap == '/')
     {
-        LS_ERROR("[GEO] %s missing DB alias in %s", env_title, 
+        LS_ERROR("[GEO] %s missing DB alias in %s", env_title,
                  pEnvAliasMapInitial);
         return -1;
     }
     const char *slash = strchr(pMap,'/');
     if (!slash)
     {
-        LS_ERROR("[GEO] %s missing alias map in %s (%s)", env_title, 
+        LS_ERROR("[GEO] %s missing alias map in %s (%s)", env_title,
                  pEnvAliasMapInitial, pMap);
         return -1;
     }
@@ -1086,8 +1086,8 @@ int IpToGeo2::parseEnvLine(const char *pEnvAliasMap,
 }
 
 
-int IpToGeo2::validateEnv(const char *pEnvAliasMap, const char *variable, 
-                          const char *database, const char *map, int *db, 
+int IpToGeo2::validateEnv(const char *pEnvAliasMap, const char *variable,
+                          const char *database, const char *map, int *db,
                           int *found)
 {
     const char *env_title = "MaxMindDBEnv";
@@ -1098,7 +1098,7 @@ int IpToGeo2::validateEnv(const char *pEnvAliasMap, const char *variable,
         {
             if (!m_dbs[i].m_nenv)
             {
-                LS_DBG("[GEO] FIRST env! %s=%s%s DB #%d\n", variable, database, 
+                LS_DBG("[GEO] FIRST env! %s=%s%s DB #%d\n", variable, database,
                        map, i);
                 *db = i;
                 return 0;
@@ -1114,24 +1114,24 @@ int IpToGeo2::validateEnv(const char *pEnvAliasMap, const char *variable,
                     break;
                 }
             }
-            LS_DBG("[GEO] Env FOUND! %s=%s%s DB #%d\n", variable, database, 
+            LS_DBG("[GEO] Env FOUND! %s=%s%s DB #%d\n", variable, database,
                    map, i);
             (*db) = i;
             return 0;
         }
     }
-    LS_ERROR("[GEO] Environment variable database not found: %s\n", 
+    LS_ERROR("[GEO] Environment variable database not found: %s\n",
              pEnvAliasMap);
     return -1;
 }
 
 
-int IpToGeo2::addEnv(const char *pEnvAliasMap, const char *variable, 
+int IpToGeo2::addEnv(const char *pEnvAliasMap, const char *variable,
                      const char *database, const char *map, const int db)
 {
     const char *env_title = "MaxMindDBEnv";
     env_t *arr;
-    
+
     if (db > m_ndbs)
     {
         LS_ERROR("[GEO] addEnv Unexpected db #%d, current num: %d\n", db, m_ndbs);
@@ -1139,9 +1139,9 @@ int IpToGeo2::addEnv(const char *pEnvAliasMap, const char *variable,
     }
     LS_DBG("[GEO] addEnv db #%d (of %d) n_env: %d, add %s=%s\n", db, m_ndbs,
            m_dbs[db].m_nenv, variable, map);
-    arr = (env_t *)ls_prealloc(m_dbs[db].m_env, 
+    arr = (env_t *)ls_prealloc(m_dbs[db].m_env,
                                sizeof(env_t) * (m_dbs[db].m_nenv + 1));
-    if (!arr) 
+    if (!arr)
     {
         LS_ERROR("[GEO] for %s Insufficient memory to allocate space for "
                  "env: %s\n",env_title, pEnvAliasMap);
@@ -1154,7 +1154,7 @@ int IpToGeo2::addEnv(const char *pEnvAliasMap, const char *variable,
     m_dbs[db].m_env[index].m_var = ls_pdupstr(variable);
     m_dbs[db].m_env[index].m_key = ls_pdupstr(map);
 
-    if ((!m_dbs[db].m_env[index].m_var) || 
+    if ((!m_dbs[db].m_env[index].m_var) ||
         (!m_dbs[db].m_env[index].m_key))
     {
         LS_ERROR("[GEO] Insufficient memory to allocate space for env values: %s\n",
@@ -1189,7 +1189,7 @@ int IpToGeo2::configSetEnv(const char *pEnvAliasMap)
 
 int IpToGeo2::defaultEnv()
 {
-    LS_DBG("[GEO] defaultEnv %d DBs, default DBs: %d\n", m_ndbs, 
+    LS_DBG("[GEO] defaultEnv %d DBs, default DBs: %d\n", m_ndbs,
            (int)(sizeof(s_db_default) / sizeof(dbs_t)));
     m_did_add_env_default = 1;
     for (int i = 0; i < m_ndbs; ++i)
@@ -1203,11 +1203,11 @@ int IpToGeo2::defaultEnv()
                 for (int e = 0; e < s_db_default[defDb].m_nenv; ++e)
                 {
                     char env[MAX_PATH_LEN * 3];
-                    snprintf(env, sizeof(env), "%s %s%s", 
+                    snprintf(env, sizeof(env), "%s %s%s",
                              s_db_default[defDb].m_env[e].m_var,
                              m_dbs[i].m_logical,
                              s_db_default[defDb].m_env[e].m_key);
-                    
+
                     LS_DBG("[GEO]    Try to add %s\n", env);
                     if (configSetEnv(env) == -1)
                         return -1;
@@ -1229,14 +1229,14 @@ GeoInfo * IpToGeo2::lookUpSA(struct sockaddr *sa)
 {
     int one_worked = 0;
     if (sa->sa_family == AF_INET)
-        LS_DBG("[GEO] LookUp of %u.%u.%u.%u\n", 
+        LS_DBG("[GEO] LookUp of %u.%u.%u.%u\n",
                (unsigned char)((char *)&((struct sockaddr_in *)sa)->sin_addr)[0],
                (unsigned char)((char *)&((struct sockaddr_in *)sa)->sin_addr)[1],
                (unsigned char)((char *)&((struct sockaddr_in *)sa)->sin_addr)[2],
                (unsigned char)((char *)&((struct sockaddr_in *)sa)->sin_addr)[3]);
     else
         LS_DBG("[GEO] LookUp of IPv6\n");
-        
+
     // Note that addr is already in line byte order
     if (!m_ndbs)
     {
@@ -1250,7 +1250,7 @@ GeoInfo * IpToGeo2::lookUpSA(struct sockaddr *sa)
             LS_ERROR("[GEO] Error setting default ENV\n");
             return NULL;
         }
-        
+
     GeoIpData2::db_found_t *db_found = (GeoIpData2::db_found_t *)ls_palloc(
         sizeof(GeoIpData2::db_found_t) * m_ndbs);
     if (!db_found)
@@ -1272,7 +1272,7 @@ GeoInfo * IpToGeo2::lookUpSA(struct sockaddr *sa)
     {
         MMDB_lookup_result_s res;
         int dberr;
-        
+
         pInfo->m_db_found[i].m_list = NULL;
         res = MMDB_lookup_sockaddr(m_dbs[i].m_mmdb, sa, &dberr);
         if (dberr != 0)
@@ -1282,10 +1282,10 @@ GeoInfo * IpToGeo2::lookUpSA(struct sockaddr *sa)
         else
         {
             // Found
-            dberr = MMDB_get_entry_data_list(&res.entry, 
+            dberr = MMDB_get_entry_data_list(&res.entry,
                                              &pInfo->m_db_found[i].m_list);
             if (dberr != 0)
-                LS_ERROR("[GEO] Get data entry list failed: %s\n", 
+                LS_ERROR("[GEO] Get data entry list failed: %s\n",
                          MMDB_strerror(dberr));
             else
             {

--- a/src/http/iptogeo2.h
+++ b/src/http/iptogeo2.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -48,12 +48,12 @@ public:
     typedef struct db_found_s db_found_t;
 
 private:
-    IpToGeo2 *m_IpToGeo2;    
+    IpToGeo2 *m_IpToGeo2;
     db_found_t *m_db_found;
     int parseEnv();
     int m_did_parse_env;
     int m_tried_parse_env;
-    
+
     char *strutf8(MMDB_entry_data_s *entry_data, char *key);
     char *strint(MMDB_entry_data_s *entry_data, char *key);
     char *strdouble(MMDB_entry_data_s *entry_data, char *key);
@@ -63,12 +63,12 @@ private:
     char *extractInt(MMDB_entry_data_s *entry_data);
     char *extractDouble(MMDB_entry_data_s *entry_data);
     char *extractBoolean(MMDB_entry_data_s *entry_data);
-    int process_map_key(int db, char *key, 
+    int process_map_key(int db, char *key,
                         MMDB_entry_data_list_s *entry_data_list);
-    int process_array_entry(int db, char *key,  
+    int process_array_entry(int db, char *key,
                             MMDB_entry_data_s *entry_data);
-    int check_entry_data_list(int db, MMDB_entry_data_list_s *entry_data_list, 
-                              MMDB_entry_data_list_s **entry_data_list_next, 
+    int check_entry_data_list(int db, MMDB_entry_data_list_s *entry_data_list,
+                              MMDB_entry_data_list_s **entry_data_list_next,
                               char *key_full);
     int simple_data_type(MMDB_entry_data_s *entry_data);
     char *extract_simple_data(MMDB_entry_data_s *entry_data);
@@ -98,7 +98,7 @@ public:
     // Called only after config and setEnv
     GeoInfo *lookUp(uint32_t addr);
     GeoInfo *lookUpV6(in6_addr addr);
-    // Just for IpToGeo2 
+    // Just for IpToGeo2
     GeoInfo *lookUp(const char *pIP);
     GeoInfo *lookUpV6(const char *pIP);
 
@@ -119,9 +119,9 @@ private:
                      char *variable, int var_len,
                      char *database, int database_len,
                      char *map, int map_len);
-    int validateEnv(const char *pEnvAliasMap, const char *variable, 
+    int validateEnv(const char *pEnvAliasMap, const char *variable,
                     const char *database, const char *map, int *db, int *found);
-    int addEnv(const char *pEnvAliasMap, const char *variable, 
+    int addEnv(const char *pEnvAliasMap, const char *variable,
                const char *database, const char *map, const int db);
     int defaultEnv();
 public:
@@ -129,7 +129,7 @@ public:
     typedef struct env_s env_t;
     struct dbs_s;
     typedef struct dbs_s dbs_t;
-private:    
+private:
     int    m_ndbs;
     dbs_t *m_dbs;
     int    m_did_add_env;

--- a/src/http/iptoloc.cpp
+++ b/src/http/iptoloc.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/iptoloc.h
+++ b/src/http/iptoloc.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/l4handler.cpp
+++ b/src/http/l4handler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/l4handler.h
+++ b/src/http/l4handler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/ls_http_header.h
+++ b/src/http/ls_http_header.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/moduserdir.cpp
+++ b/src/http/moduserdir.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/moduserdir.h
+++ b/src/http/moduserdir.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/moov.cpp
+++ b/src/http/moov.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/moov.h
+++ b/src/http/moov.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/moovP.h
+++ b/src/http/moovP.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/mtsessdata.h
+++ b/src/http/mtsessdata.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/nshttp.h
+++ b/src/http/nshttp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/ntwkiolink.cpp
+++ b/src/http/ntwkiolink.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/ntwkiolink.h
+++ b/src/http/ntwkiolink.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/phpconfig.cpp
+++ b/src/http/phpconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/phpconfig.h
+++ b/src/http/phpconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/pipeappender.cpp
+++ b/src/http/pipeappender.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/pipeappender.h
+++ b/src/http/pipeappender.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/platforms.h
+++ b/src/http/platforms.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/recaptcha.cpp
+++ b/src/http/recaptcha.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/recaptcha.h
+++ b/src/http/recaptcha.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -36,7 +36,7 @@ public:
         TYPE_END,
         TYPE_V3, // not out yet.
     };
-    
+
     Recaptcha();
     ~Recaptcha();
 

--- a/src/http/reqhandler.cpp
+++ b/src/http/reqhandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/reqhandler.h
+++ b/src/http/reqhandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/reqparser.cpp
+++ b/src/http/reqparser.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/reqparser.h
+++ b/src/http/reqparser.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -82,14 +82,14 @@ public:
     bool getEnableUploadFile()  {   return m_pFileUploadConfig != NULL; }
     int  isParsePost() const    {   return m_iParseState == PARSE_START;   }
     bool isParseDone() const    {   return m_iParseState == PARSE_DONE; }
-    bool isParseUploadByFilePath() const 
+    bool isParseUploadByFilePath() const
     {   return m_pFileUploadConfig != NULL; }
 
     int  beginParsePost();
 
     const char *getReqVar(HttpSession *pSession, int varId, int &len,
                           char *pBegin, int bufLen);
-    
+
     int getArgCount() const         {   return m_args;      }
     int getQsArgCount() const       {   return m_qsArgs;    }
     int getPostArgCount() const     {   return m_postArgs;  }
@@ -101,17 +101,17 @@ public:
         return getArgByIndex(index + m_qsBegin, pArg, NULL);
     }
     int getPostArgByIndex(int index, ls_strpair_t *pArg, char **filePath)
-    {   
+    {
         if (index < 0 || index >= m_postArgs)
             return -1;
         return getArgByIndex(index + m_postArgs, pArg, filePath);
     }
-    
-    bool isFile(int index) 
-    { 
+
+    bool isFile(int index)
+    {
         if (index < 0 || index > m_args)
             return false;
-        return (m_pArgs[index].filePath != NULL);  
+        return (m_pArgs[index].filePath != NULL);
     }
 
 

--- a/src/http/reqparserparam.h
+++ b/src/http/reqparserparam.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/reqstats.cpp
+++ b/src/http/reqstats.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/reqstats.h
+++ b/src/http/reqstats.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/requestvars.cpp
+++ b/src/http/requestvars.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/requestvars.h
+++ b/src/http/requestvars.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriteengine.cpp
+++ b/src/http/rewriteengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriteengine.h
+++ b/src/http/rewriteengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewritemap.cpp
+++ b/src/http/rewritemap.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewritemap.h
+++ b/src/http/rewritemap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriterule.cpp
+++ b/src/http/rewriterule.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriterule.h
+++ b/src/http/rewriterule.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriterulelist.cpp
+++ b/src/http/rewriterulelist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/rewriterulelist.h
+++ b/src/http/rewriterulelist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/sendfileinfo.cpp
+++ b/src/http/sendfileinfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/sendfileinfo.h
+++ b/src/http/sendfileinfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/serverprocessconfig.cpp
+++ b/src/http/serverprocessconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/serverprocessconfig.h
+++ b/src/http/serverprocessconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/smartsettings.cpp
+++ b/src/http/smartsettings.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/smartsettings.h
+++ b/src/http/smartsettings.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/staticfilecache.cpp
+++ b/src/http/staticfilecache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/staticfilecache.h
+++ b/src/http/staticfilecache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/staticfilecachedata.cpp
+++ b/src/http/staticfilecachedata.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/staticfilecachedata.h
+++ b/src/http/staticfilecachedata.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -42,7 +42,7 @@ class FileCacheDataEx : public RefCounter
     friend class StaticFileCacheData;
 
     AutoStr2        m_sCLHeader;
-    
+
     int             m_fd;
     off_t           m_lSize;
     ino_t           m_inode;
@@ -79,7 +79,7 @@ public:
     void setStatus(int status)    {   m_iStatus = status; }
     int  getStatus()  const         {   return m_iStatus;   }
 
-   
+
     int  isCached() const           {   return m_iStatus;  }
     int  isMapped() const
     {   return (m_iStatus == MMAPED);     }
@@ -150,7 +150,7 @@ class StaticFileCacheData : public CacheElement
     int buildFixedHeaders(int etag);
     int buildCompressedCache(FileCacheDataEx *&pData, const struct stat &st);
     int tryCreateCompressed(char useBrotli);
-    
+
     int buildCompressedPaths();
     int detectTrancate();
 
@@ -194,14 +194,14 @@ public:
 
     int getBypassModsec() const         { return m_bypassModsec;    }
     void setBypassModsec(int v)         { m_bypassModsec = v; }
-    
+
     int testMod(HttpReq *pReq);
     int testUnMod(HttpReq *pReq);
     int testIfRange(const char *pIR, int len);
     int release();
     time_t getLastMod() const       {   return m_fileData.getLastMod();   }
     ino_t getINode() const          {   return m_fileData.getINode();     }
-    
+
     bool isDirty(const struct stat &fileStat) const
     {   return m_fileData.isDirty(fileStat);      }
     int needUpdateHeaders(const MimeSetting *pMIME,

--- a/src/http/staticfilehandler.cpp
+++ b/src/http/staticfilehandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/staticfilehandler.h
+++ b/src/http/staticfilehandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/statusurlmap.cpp
+++ b/src/http/statusurlmap.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/statusurlmap.h
+++ b/src/http/statusurlmap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/stderrlogger.cpp
+++ b/src/http/stderrlogger.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/stderrlogger.h
+++ b/src/http/stderrlogger.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/subrequest.cpp
+++ b/src/http/subrequest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/throttlecontrol.cpp
+++ b/src/http/throttlecontrol.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/throttlecontrol.h
+++ b/src/http/throttlecontrol.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/urimatch.cpp
+++ b/src/http/urimatch.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/urimatch.h
+++ b/src/http/urimatch.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/userdir.cpp
+++ b/src/http/userdir.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/userdir.h
+++ b/src/http/userdir.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/vhostmap.cpp
+++ b/src/http/vhostmap.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/http/vhostmap.h
+++ b/src/http/vhostmap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -124,14 +124,14 @@ private:
     typedef THash<VHostMap *>      IpMap;
     IpMap       m_map;
     SslContext       *m_pSslContext;
-    
-    
+
+
     SubIpMap(const SubIpMap &rhs);
     void operator=(const SubIpMap &rhs);
 public:
     SubIpMap();
     ~SubIpMap();
-    
+
     SslContext *getSslContext() const      {   return m_pSslContext;   }
     void setDefaultSslCtx(SslContext *p);
 

--- a/src/httpdtest.cpp
+++ b/src/httpdtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/httpdtest.h
+++ b/src/httpdtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/ediohandler.cpp
+++ b/src/lsiapi/ediohandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/ediohandler.h
+++ b/src/lsiapi/ediohandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/envmanager.cpp
+++ b/src/lsiapi/envmanager.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -25,7 +25,7 @@ LS_SINGLETON(EnvManager);
 
 EnvManager::EnvManager()
 {
-    m_pEnvHashT = new HashStringMap<EnvHandler *>(29, 
+    m_pEnvHashT = new HashStringMap<EnvHandler *>(29,
                                                   GHash::hfCiString,
                                                   GHash::cmpCiString);
 }

--- a/src/lsiapi/envmanager.h
+++ b/src/lsiapi/envmanager.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/internal.h
+++ b/src/lsiapi/internal.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapi.cpp
+++ b/src/lsiapi/lsiapi.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapi.h
+++ b/src/lsiapi/lsiapi.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapi_const.cpp
+++ b/src/lsiapi/lsiapi_const.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -50,7 +50,7 @@ int LsiApiConst::get_cgi_header_count(void)
 }
 
 
-const char *LsiApiConst::get_cgi_header(int index) 
+const char *LsiApiConst::get_cgi_header(int index)
 {
     return CGI_HEADERS[index];
 }

--- a/src/lsiapi/lsiapi_const.h
+++ b/src/lsiapi/lsiapi_const.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -25,10 +25,10 @@ class LsiApiConst
 {
 public:
     static int get_cgi_header_count(void);
-    
+
     static const char *get_cgi_header(int index);
     static const char **get_cgi_header_array(void);
-    
+
     static int get_cgi_header_len(int index);
     static const int *get_cgi_header_len_array(void);
 };

--- a/src/lsiapi/lsiapigd.cpp
+++ b/src/lsiapi/lsiapigd.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapigd.h
+++ b/src/lsiapi/lsiapigd.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapihooks.cpp
+++ b/src/lsiapi/lsiapihooks.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapihooks.h
+++ b/src/lsiapi/lsiapihooks.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapilib.cpp
+++ b/src/lsiapi/lsiapilib.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsiapilib.h
+++ b/src/lsiapi/lsiapilib.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsimoduledata.cpp
+++ b/src/lsiapi/lsimoduledata.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/lsimoduledata.h
+++ b/src/lsiapi/lsimoduledata.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/modulehandler.cpp
+++ b/src/lsiapi/modulehandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/modulehandler.h
+++ b/src/lsiapi/modulehandler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -36,7 +36,7 @@ public:
     virtual int process(HttpSession *pSession, const HttpHandler *pHandler);
     virtual void onTimer() {};
     virtual int onRead(HttpSession *pSession);
-    
+
     static  void initGlobalWorkCrew();
     static  WorkCrew *getGlobalWorkCrew();
 
@@ -45,7 +45,7 @@ private:
     int mt_onWrite(HttpSession *pSession, const lsi_reqhdlr_t *pModuleHandler);
     int mt_process(HttpSession *pSession, const lsi_reqhdlr_t *pModuleHandler);
     int mt_onRead(HttpSession *pSession, const lsi_reqhdlr_t *pModuleHandler);
-    
+
 };
 
 #endif // MODULEHANDLER_H

--- a/src/lsiapi/modulemanager.cpp
+++ b/src/lsiapi/modulemanager.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/modulemanager.h
+++ b/src/lsiapi/modulemanager.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/moduletimer.cpp
+++ b/src/lsiapi/moduletimer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsiapi/moduletimer.h
+++ b/src/lsiapi/moduletimer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/ls_internal.h
+++ b/src/lsr/ls_internal.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/ls_memcheck.h
+++ b/src/lsr/ls_memcheck.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -18,7 +18,7 @@
 #ifndef _LS_MEMCHECK_H_
 #define _LS_MEMCHECK_H_
 
-//this file is not available under gcc 
+//this file is not available under gcc
 //#include <sanitizer/asan_interface.h>
 
 //add our own
@@ -43,7 +43,7 @@ extern "C" {
 #define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
   __asan_unpoison_memory_region((addr), (size))
 #else
-#define ASAN_POISON_MEMORY_REGION(addr, size) 
+#define ASAN_POISON_MEMORY_REGION(addr, size)
 #define ASAN_UNPOISON_MEMORY_REGION(addr, size)
 #endif
 
@@ -63,21 +63,21 @@ extern "C" {
 #define VG_DEL_POOL(a)
 #define VG_POOL_ALLOC(a, b, c)
 #define VG_POOL_FREE(a, b)
-#define VG_POISON(a, b) 
-#define VG_UNPOISON(a, b) 
+#define VG_POISON(a, b)
+#define VG_UNPOISON(a, b)
 #endif /* USE_VALGRIND */
-        
-#define ASAN_POISON(p, s)       ASAN_POISON_MEMORY_REGION(p, s)
-#define ASAN_UNPOISON(p, s)     ASAN_UNPOISON_MEMORY_REGION(p, s)    
 
-#define MEMCHK_NEWPOOL(pool, b, c)  VG_NEW_POOL(pool, b, c) 
+#define ASAN_POISON(p, s)       ASAN_POISON_MEMORY_REGION(p, s)
+#define ASAN_UNPOISON(p, s)     ASAN_UNPOISON_MEMORY_REGION(p, s)
+
+#define MEMCHK_NEWPOOL(pool, b, c)  VG_NEW_POOL(pool, b, c)
 #define MEMCHK_DESTROY_POOL(pool)   VG_DEL_POOL(pool)
 
 #define MEMCHK_POISON_CHKNUL(p, s) \
     do { if (p != NULL) {VG_POISON(p, s); ASAN_POISON(p, s); } } while(0)
 #define MEMCHK_POISON(p, s) \
     do { VG_POISON(p, s); ASAN_POISON(p, s); } while(0)
-        
+
 #define MEMCHK_UNPOISON_CHKNUL(p, s) \
     do { if (p != NULL) {VG_UNPOISON(p, s); ASAN_UNPOISON(p, s); } } while(0)
 #define MEMCHK_UNPOISON(p, s) \
@@ -85,13 +85,13 @@ extern "C" {
 
 #define MEMCHK_ALLOC(pool, p, s) \
     do { VG_POOL_ALLOC(pool, p, s); ASAN_UNPOISON(p, s); } while(0)
-    
+
 #define MEMCHK_ALLOC_CHKNUL(pool, p, s) \
     do { if (p != NULL) {VG_POOL_ALLOC(pool, p, s); ASAN_UNPOISON(p, s); } } while(0)
 
 #define MEMCHK_FREE(pool, p, s) \
     do { VG_POOL_FREE(pool, p); ASAN_POISON(p, s); } while(0)
-    
-        
+
+
 #endif      //_LS_MEMCEHCK_H_
 

--- a/src/lsr/ls_pooldef.h
+++ b/src/lsr/ls_pooldef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/ls_poolint.h
+++ b/src/lsr/ls_poolint.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/ls_shm.cpp
+++ b/src/lsr/ls_shm.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/ls_threadcheck.h
+++ b/src/lsr/ls_threadcheck.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -44,7 +44,7 @@
 #define LS_TH_NOT_BEFORE_MUTEX(mu) ANNOTATE_NOT_HAPPENS_BEFORE_MUTEX(mu)
 #define LS_TH_BENIGN(a,b) ANNOTATE_BENIGN_RACE(a,b)
 #define LS_TH_EXPECT(a,b) ANNOTATE_EXPECT_RACE(a,b)
-#define LS_TH_FLUSH() ANNOTATE_FLUSH_EXPECTED_RACES() 
+#define LS_TH_FLUSH() ANNOTATE_FLUSH_EXPECTED_RACES()
 
 #else /* no checking or no thread sanitizer */
 

--- a/src/lsr/ls_xpool_int.h
+++ b/src/lsr/ls_xpool_int.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lsr/xxhash.h
+++ b/src/lsr/xxhash.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/lstl/thash.h
+++ b/src/lstl/thash.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/configctx.cpp
+++ b/src/main/configctx.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/configctx.h
+++ b/src/main/configctx.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/httpconfigloader.cpp
+++ b/src/main/httpconfigloader.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/httpconfigloader.h
+++ b/src/main/httpconfigloader.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/httpserver.cpp
+++ b/src/main/httpserver.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/httpserver.h
+++ b/src/main/httpserver.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/lshttpdmain.cpp
+++ b/src/main/lshttpdmain.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/lshttpdmain.h
+++ b/src/main/lshttpdmain.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/mainserverconfig.cpp
+++ b/src/main/mainserverconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/mainserverconfig.h
+++ b/src/main/mainserverconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/plainconf.cpp
+++ b/src/main/plainconf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/plainconf.h
+++ b/src/main/plainconf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/serverinfo.cpp
+++ b/src/main/serverinfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/serverinfo.h
+++ b/src/main/serverinfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/timestamp.h
+++ b/src/main/timestamp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/zconfclient.cpp
+++ b/src/main/zconfclient.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/zconfclient.h
+++ b/src/main/zconfclient.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/zconfmanager.cpp
+++ b/src/main/zconfmanager.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/main/zconfmanager.h
+++ b/src/main/zconfmanager.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/js/lsjsengine.cpp
+++ b/src/modules/js/lsjsengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/js/lsjsengine.h
+++ b/src/modules/js/lsjsengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/js/modjs.cpp
+++ b/src/modules/js/modjs.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/js/modjs.h
+++ b/src/modules/js/modjs.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/edluastream.cpp
+++ b/src/modules/lua/edluastream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/edluastream.h
+++ b/src/modules/lua/edluastream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluaapi.cpp
+++ b/src/modules/lua/lsluaapi.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluaapi.h
+++ b/src/modules/lua/lsluaapi.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluadefs.h
+++ b/src/modules/lua/lsluadefs.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluaengine.cpp
+++ b/src/modules/lua/lsluaengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -538,7 +538,7 @@ static int setFileHook(int index, module_param_info_t *param,
                    myParam[param->key_index].config_key);
         return -1;
     }
-    
+
     pUser->setFilterPath(index, param->val, param->val_len);
     g_api->log(NULL, LSI_LOG_NOTICE,
                "%s LUA SET %s = %.*s\n",
@@ -573,7 +573,7 @@ void *LsLuaEngine::parseParam(module_param_info_t *param, int param_count,
         return pUser;
     }
 
-    
+
     for (int i=0; i<param_count; ++i)
     {
         switch(param[i].key_index)
@@ -652,7 +652,7 @@ void *LsLuaEngine::parseParam(module_param_info_t *param, int param_count,
                        pUser->getMaxRunTime(),
                        pUser->getMaxRunTime() ? "ENABLED" : "DISABLED");
             break;
-            
+
         case 7:
             //"maxlinecount"
             if ((line = strtol(param[i].val, NULL, 0)) >= 0)
@@ -669,7 +669,7 @@ void *LsLuaEngine::parseParam(module_param_info_t *param, int param_count,
                        pUser->getMaxLineCount(),
                        pUser->getMaxLineCount() ? "ENABLED" : "DISABLED");
             break;
-            
+
         case 8:
             //"jitlinemod"
             if ((line = strtol(param[i].val, NULL, 0)) > 0)
@@ -681,7 +681,7 @@ void *LsLuaEngine::parseParam(module_param_info_t *param, int param_count,
                        param[i].val,
                        s_iJitLineMod);
             break;
-            
+
         case 9:
             //"pause"
             if ((sec = strtol(param[i].val, NULL, 0)) > 0)

--- a/src/modules/lua/lsluaengine.h
+++ b/src/modules/lua/lsluaengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluaheader.cpp
+++ b/src/modules/lua/lsluaheader.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluaregex.cpp
+++ b/src/modules/lua/lsluaregex.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluasession.cpp
+++ b/src/modules/lua/lsluasession.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluasession.h
+++ b/src/modules/lua/lsluasession.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/lsluashared.cpp
+++ b/src/modules/lua/lsluashared.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/lua/modlua.cpp
+++ b/src/modules/lua/modlua.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -182,7 +182,7 @@ static int luaHandler(const lsi_session_t *session)
     g_api->set_handler_write_state(session, 0);
     int debLevel = 0;
     if (*g_api->_log_level_ptr >= LSI_LOG_DEBUG)
-        debLevel = (*g_api->_log_level_ptr - LSI_LOG_DEBUG) / 10; 
+        debLevel = (*g_api->_log_level_ptr - LSI_LOG_DEBUG) / 10;
     LsLuaEngine::setDebugLevel(debLevel);
     return LsLuaEngine::runScript(session, luafile, pUser,
                                   &(pData->m_pSession), LSLUA_HOOK_HANDLER);
@@ -273,7 +273,7 @@ lsi_config_key_t myParam[] =
     {"maxruntime", 0, 0},
     {"maxlinecount", 0, 0},
     {"jitlinemod", 0, 0},
-    {"pause", 0, 0}, 
+    {"pause", 0, 0},
     {NULL, 0, 0}
 };
 

--- a/src/modules/mod_lsphp/src/mod_lsphp.h
+++ b/src/modules/mod_lsphp/src/mod_lsphp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/modgzip/modgzip.cpp
+++ b/src/modules/modgzip/modgzip.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/modinspector/modinspector.cpp
+++ b/src/modules/modinspector/modinspector.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -56,7 +56,7 @@ static void *modinspector_parseConfig(module_param_info_t *param, int param_coun
     if (!myConf)
         return NULL;
 
-    
+
     memset(myConf, 0, sizeof(scanner_param_st));
     if (param == NULL || param_count <= 0)
     {

--- a/src/modules/modreqparser/modreqparser.cpp
+++ b/src/modules/modreqparser/modreqparser.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -34,7 +34,7 @@
 extern lsi_module_t MNAME;
 /***
  * Set the config of this module in SERVER, VHOST and context level as below
- * uploadTmpDir              /tmp/lshttpd/ 
+ * uploadTmpDir              /tmp/lshttpd/
  * uploadTmpFilePermission   666
  * uploadPassByPath          1
  */
@@ -97,7 +97,7 @@ static void *_parseConfig(module_param_info_t *param, int param_count,
         case 1:
             pConfig->permission = strtol(param[i].val, NULL, 8);
             break;
-            
+
         case 2:
             pConfig->byPath = strtol(param[i].val, NULL, 10);
             break;
@@ -125,7 +125,7 @@ static int enableReqParser(lsi_param_t *rec)
                    "[%s]enableReqParser error 1.\n", ModuleNameStr);
         return 0;
     }
-    
+
     g_api->parse_req_args(rec->session, 1, pConfig->byPath, pConfig->tmpDir->c_str(),
                           pConfig->permission);
     return 0;

--- a/src/modules/modsecurity-ls/mod_security.cpp
+++ b/src/modules/modsecurity-ls/mod_security.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/log_message_handler.cpp
+++ b/src/modules/pagespeed/log_message_handler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/log_message_handler.h
+++ b/src/modules/pagespeed/log_message_handler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_base_fetch.cpp
+++ b/src/modules/pagespeed/ls_base_fetch.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -91,7 +91,7 @@ bool LsiBaseFetch::HandleWrite(const StringPiece &sp,
                                MessageHandler *handler)
 {
 //This will create a lot of log, disable it currently
-//     g_api->log(NULL, LSI_LOG_DEBUG, 
+//     g_api->log(NULL, LSI_LOG_DEBUG,
 //                "[Thr:PAGESPEED] LsiBaseFetch::HandleWrite(), "
 //                "Response body: %zd bytes.\n", sp.size());
     Lock();
@@ -139,9 +139,9 @@ int LsiBaseFetch::CollectHeaders(const lsi_session_t *session)
     int content_len_set = content_length_known();
     if (content_len_set)
         g_api->set_resp_content_length(session, content_length());
-    g_api->log(session, LSI_LOG_DEBUG, 
+    g_api->log(session, LSI_LOG_DEBUG,
                "[modpagespeed] LsiBaseFetch::CollectHeaders(), "
-               "content-len known: %d, call CopyRespHeadersToServer()\n", 
+               "content-len known: %d, call CopyRespHeadersToServer()\n",
                content_len_set);
 
     return CopyRespHeadersToServer((lsi_session_t *)session, *pagespeed_headers,
@@ -161,7 +161,7 @@ void LsiBaseFetch::HandleHeadersComplete()
 {
     int statusCode = response_headers()->status_code();
     bool statusOk = (statusCode != 0 && statusCode < 400);
-    g_api->log(NULL, LSI_LOG_DEBUG, 
+    g_api->log(NULL, LSI_LOG_DEBUG,
                "[Thr:PAGESPEED] LsiBaseFetch::HandleHeadersComplete(), "
                "status code: %d.\n", statusCode);
 
@@ -180,7 +180,7 @@ void LsiBaseFetch::HandleHeadersComplete()
 
 bool LsiBaseFetch::HandleFlush(MessageHandler *handler)
 {
-    g_api->log(NULL, LSI_LOG_DEBUG, 
+    g_api->log(NULL, LSI_LOG_DEBUG,
                "[Thr:PAGESPEED] LsiBaseFetch::HandleFlush().\n");
     //RequestCollection();
     return true;
@@ -204,7 +204,7 @@ void LsiBaseFetch::HandleDone(bool success)
     Lock();
     m_bDoneCalled = true;
     Unlock();
-    g_api->log(NULL, LSI_LOG_DEBUG, 
+    g_api->log(NULL, LSI_LOG_DEBUG,
                "[Thr:PAGESPEED] LsiBaseFetch::HandleDone(%d), "
                "RequestCollection() for event: %ld\n", success, m_lEventObj);
     RequestCollection();

--- a/src/modules/pagespeed/ls_base_fetch.h
+++ b/src/modules/pagespeed/ls_base_fetch.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_caching_headers.cpp
+++ b/src/modules/pagespeed/ls_caching_headers.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_caching_headers.h
+++ b/src/modules/pagespeed/ls_caching_headers.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_message_handler.cpp
+++ b/src/modules/pagespeed/ls_message_handler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_message_handler.h
+++ b/src/modules/pagespeed/ls_message_handler.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_rewrite_driver_factory.cpp
+++ b/src/modules/pagespeed/ls_rewrite_driver_factory.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_rewrite_driver_factory.h
+++ b/src/modules/pagespeed/ls_rewrite_driver_factory.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -62,7 +62,7 @@ public:
     bool InitLsiUrlAsyncFetchers();
 
     static void InitStats(Statistics *statistics);
-    LsServerContext *MakeLsServerContext(StringPiece hostname, int port, 
+    LsServerContext *MakeLsServerContext(StringPiece hostname, int port,
                                          int uninitialized);
     virtual ServerContext *NewServerContext();
 

--- a/src/modules/pagespeed/ls_rewrite_options.cpp
+++ b/src/modules/pagespeed/ls_rewrite_options.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_rewrite_options.h
+++ b/src/modules/pagespeed/ls_rewrite_options.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_server_context.cpp
+++ b/src/modules/pagespeed/ls_server_context.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_server_context.h
+++ b/src/modules/pagespeed/ls_server_context.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/ls_uamatcher.cpp
+++ b/src/modules/pagespeed/ls_uamatcher.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -30,14 +30,14 @@ LsUAMatcher::LsUAMatcher()
 LsUAMatcher::~LsUAMatcher()
 {
     ls_hash_iter it;
-    for (it = ls_hash_begin(m_pHash); it != ls_hash_end(m_pHash); 
+    for (it = ls_hash_begin(m_pHash); it != ls_hash_end(m_pHash);
          it = ls_hash_next(m_pHash, it))
     {
         ua_hash_item *pItem = (ua_hash_item *)ls_hash_getdata(it);
         free(pItem->ua);
         delete pItem;
     }
-    
+
     ls_hash_delete(m_pHash);
     delete m_pUAMatcher;
 }
@@ -63,7 +63,7 @@ uint32_t LsUAMatcher::getUaCode(const char *ua_str)
         pItem->ua = ::strdup(ua_str);
         pItem->code = 0;
         StringPiece ua = ua_str;
-        
+
         UserAgentMatcher::DeviceType type = m_pUAMatcher->GetDeviceTypeForUA(ua);
         switch(type)
         {
@@ -80,47 +80,47 @@ uint32_t LsUAMatcher::getUaCode(const char *ua_str)
                 //pItem->code |= ua_unknown_device;
                 break;
         }
-        
+
         if (m_pUAMatcher->SupportsImageInlining(ua))
             pItem->code |= ua_supports_image_inlining;
 
         if (m_pUAMatcher->SupportsLazyloadImages(ua))
             pItem->code |= ua_supports_lazyload_images;
-                
+
         if (m_pUAMatcher->SupportsJsDefer(ua, true))
             pItem->code |= ua_defer_js_whitelist;
-              
+
         if (m_pUAMatcher->LegacyWebp(ua))
             pItem->code |= ua_legacy_webp;
 
 //         if (m_pUAMatcher->InsightsWebp(ua))
 //             pItem->code |= ua_pagespeed_insights;
-            
+
         if (m_pUAMatcher->SupportsWebpLosslessAlpha(ua))
             pItem->code |= ua_supports_webp_lossless_alpha;
-                
+
         if (m_pUAMatcher->SupportsWebpAnimated(ua))
-            pItem->code |= ua_supports_webp_animated;  
-                
+            pItem->code |= ua_supports_webp_animated;
+
         if (m_pUAMatcher->SupportsDnsPrefetch(ua))
             pItem->code |= ua_supports_dns_prefetch;
-                
+
         if (m_pUAMatcher->IsAndroidUserAgent(ua))
             pItem->code |= ua_android;
 
         if (m_pUAMatcher->IsiOSUserAgent(ua))
             pItem->code |= ua_ios;
-                
+
         if (m_pUAMatcher->SupportsMobilization(ua))
             pItem->code |= ua_mobilization_user_agents;
-                
+
         if (m_pUAMatcher->IsIe(ua_str))
             pItem->code |= ua_ie_user_agents;
         code = pItem->code;
-        
+
         ls_hash_insert(m_pHash, (void *)pItem->ua, (void *)pItem);
     }
-    
+
     return code;
 }
 
@@ -128,12 +128,12 @@ uint32_t LsUAMatcher::getUaCode(const char *ua_str)
 void UAMatcherTest()
 {
     LsUAMatcher &match = LsUAMatcher::getInstance();
-    
+
     //imageinline
     uint32_t code1 = match.getUaCode("*iPhone*");
     //DEBUG to check if it got from stored hashtable
     code1 = match.getUaCode("*iPhone*");
-    
+
     uint32_t code2 = match.getUaCode("*Chrome/*");
     uint32_t code3 = match.getUaCode("*Firefox/*");
     uint32_t code4 = match.getUaCode("*Safari*");
@@ -143,46 +143,46 @@ void UAMatcherTest()
     assert(match.testbit(code3, ua_supports_image_inlining));
     assert(match.testbit(code4, ua_supports_image_inlining));
     assert(match.testbit(code5, ua_supports_image_inlining));
-    
+
     assert(match.getDeviceType(code1) == ua_device_mobile);
     //assert(match.getDeviceType("*Android 3.*") == ua_device_mobile);
     assert(match.getDeviceType("*Kindle Fire*") == ua_device_tablet);
     assert(match.getDeviceType("*iPad*") == ua_device_tablet);
-    
-    
+
+
     uint32_t code6 = match.getUaCode("*iPhone*");
     uint32_t code7 = match.getUaCode("*Chrome/*");
     uint32_t code8 = match.getUaCode("*Firefox/*");
     assert(code1 == code6);
     assert(code2 == code7);
     assert(code3 == code8);
-    
+
     code1 = match.getUaCode("*iPhone*");
     assert(match.testbit(code1, ua_ios));
     code1 = match.getUaCode("*iPad*");
     assert(match.testbit(code1, ua_ios));
     code1 = match.getUaCode("*Android 3.*");
     assert(match.testbit(code1, ua_android));
-    
-    
-    
-    
+
+
+
+
     code1 = match.getUaCode("*iPhone*");
     assert(match.testbit(code1, ua_supports_lazyload_images));
-    
+
     uint32_t code9 = match.getUaCode("*Opera Mini*");
     assert(!match.testbit(code9, ua_supports_lazyload_images));
-    
-    
+
+
     assert(match.testbit(code7, ua_supports_dns_prefetch));
     assert(match.testbit(code8, ua_supports_dns_prefetch));
     assert(!match.testbit(code9, ua_supports_dns_prefetch));
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
 }
 
 

--- a/src/modules/pagespeed/ls_uamatcher.h
+++ b/src/modules/pagespeed/ls_uamatcher.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/pagespeed.cpp
+++ b/src/modules/pagespeed/pagespeed.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/pagespeed/pagespeed.h
+++ b/src/modules/pagespeed/pagespeed.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/prelinkedmods.cpp
+++ b/src/modules/prelinkedmods.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/modules/uploadprogress/uploadprogress.cpp
+++ b/src/modules/uploadprogress/uploadprogress.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/ls_sendmmsg.h
+++ b/src/quic/ls_sendmmsg.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/packetbuf.h
+++ b/src/quic/packetbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -34,7 +34,7 @@
  * struct sockaddr_storage peer_addr  128 bytes
  * ecn  1 byte
  * packet data (current packet length bytes)
- * 
+ *
  * PACKETBUFSZIE = 1683 (hold 40 + 4 + 4 + 4 + sizeof(struct sockaddr_storage) * 2 + QUIC_SHM_PACKET_SIZE + 1)
  */
 #define  PACKETBUFRESERVEHEAD   40

--- a/src/quic/pbset.cpp
+++ b/src/quic/pbset.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -31,7 +31,7 @@ struct SetOfPbBucket
         sopb_slots          = 1;
         sopb_packet_bufs[0] = packet_buf;
     }
-    
+
     STAILQ_ENTRY(SetOfPbBucket)    sopb_next_all;
     TAILQ_ENTRY(SetOfPbBucket)     sopb_next_avail;
     uint64_t                       sopb_slots;
@@ -94,7 +94,7 @@ SetOfPacketBuffers::removePacketBuf()
     struct SetOfPbBucket *bucket;
     struct quicshm_packet_buf *packet_buf;
     unsigned slot;
-    
+
     bucket = STAILQ_FIRST(&m_BucketsAll);
     if (bucket)
     {

--- a/src/quic/pbset.h
+++ b/src/quic/pbset.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quicengine.cpp
+++ b/src/quic/quicengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quicengine.h
+++ b/src/quic/quicengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quiclog.h
+++ b/src/quic/quiclog.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quicshm.cpp
+++ b/src/quic/quicshm.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -38,7 +38,7 @@ static pid_t s_pid = -1;
 
 void QuicShm::setPid(pid_t pid)
 {
-    s_pid = pid;    
+    s_pid = pid;
 }
 
 
@@ -60,10 +60,10 @@ QuicShm::~QuicShm()
 
     if (m_pInternalShiCtx)
         lsquic_stock_shared_hash_destroy((struct stock_shared_hash *)m_pInternalShiCtx);
-    
+
     if (m_pCidMap)
         m_pCidMap->close();
-    
+
     if (m_pPidPacketOffsetMap)
         m_pPidPacketOffsetMap->close();
 }
@@ -93,7 +93,7 @@ int QuicShm::openShmPacketPool(const char *fileName, const char *pShmDir)
         }
         m_pPacketPool->disableAutoLock();
 
-//         /* FIXME: for testing only */ 
+//         /* FIXME: for testing only */
 //         int remapped;
 //         LsShmOffset_t off;
 //         for (int i=0; i<10; ++i)
@@ -105,8 +105,8 @@ int QuicShm::openShmPacketPool(const char *fileName, const char *pShmDir)
 //                 break;
 //             }
 //         }
-//         /* FIXME: for testing only */ 
-        
+//         /* FIXME: for testing only */
+
         ret = 0;
         break;
     }
@@ -151,7 +151,7 @@ int QuicShm::openShmMapPool(const char *fileName, const char *pShmDir)
 
         m_pPidPacketOffsetMap = m_pMapPool->getNamedHash("PIDOFFSET", 5,
                                                     _self_hash, memcmp, 0);
-        
+
         m_pMapPool->unlock();
         m_pMapPool->enableAutoLock();
 
@@ -169,7 +169,7 @@ int QuicShm::openShmMapPool(const char *fileName, const char *pShmDir)
         }
         else
         {
-//             /* FIXME: for testing only */ 
+//             /* FIXME: for testing only */
 //             int remapped;
 //             LsShmOffset_t off;
 //             for (int i=0; i<10; ++i)
@@ -177,7 +177,7 @@ int QuicShm::openShmMapPool(const char *fileName, const char *pShmDir)
 //                 off = m_pMapPool->alloc2(1 * 1024 * 1024, remapped);
 //                 if (off)
 //                     m_pMapPool->release2(off, 1 * 1024 * 1024);
-//                 
+//
 //                 off = m_pMapPool->alloc2(100 * 1024 * 1024, remapped);
 //                 if (off)
 //                 {
@@ -185,7 +185,7 @@ int QuicShm::openShmMapPool(const char *fileName, const char *pShmDir)
 //                     break;
 //                 }
 //             }
-//             /* FIXME: for testing only */ 
+//             /* FIXME: for testing only */
             m_pCidMap->disableAutoLock();
             m_pPidPacketOffsetMap->disableAutoLock();
             ret = 0;
@@ -252,20 +252,20 @@ int QuicShm::insertItem(void *hash_ctx, void *key, unsigned int key_sz, void *da
     char *buf = new char[valLen];
     if (!buf)
         return -1;
-    
+
     char *p = buf;
     memcpy(p, &expiry, sizeof(time_t));
     p += sizeof(time_t);
-    
+
     memcpy(p, &key_sz, sizeof(unsigned int));
     p += sizeof(unsigned int);
-    
+
     memcpy(p, &data_sz, sizeof(unsigned int));
     p += sizeof(unsigned int);
-    
+
     memcpy(p, key, key_sz);
     p += key_sz;
-    
+
     memcpy(p, data, data_sz);
     p += data_sz;
 
@@ -288,7 +288,7 @@ int QuicShm::lookupItem(void *hash_ctx, const void *key, unsigned key_sz, void *
 
     LsShmHash *pHash = (LsShmHash *)hash_ctx;
     deleteExpiredItems(pHash);
-    
+
     ls_strpair_t parms;
     ls_str_set(&parms.key, (char *)key, key_sz);
     LsShmHash::iteroffset iterOff = pHash->findIterator(&parms);
@@ -297,13 +297,13 @@ int QuicShm::lookupItem(void *hash_ctx, const void *key, unsigned key_sz, void *
 
     LsShmHash::iterator iter = pHash->offset2iterator(iterOff);
     assert(iter);
-    
+
     int ValLen = iter->getValLen();
     uint8_t *buf = iter->getVal();
     uint8_t *p = buf;
     unsigned int key_len, data_len;
     time_t expiry;
-    
+
     memcpy(&expiry, p, sizeof(time_t));
     p += sizeof(time_t);
     memcpy(&key_len, p, sizeof(unsigned int));
@@ -321,7 +321,7 @@ int QuicShm::lookupItem(void *hash_ctx, const void *key, unsigned key_sz, void *
     void *key_copy = malloc(key_len);
     memcpy(key_copy, p, key_len);
     p += key_len;
-    
+
     *data = (char *)malloc(data_len);
     memcpy(*data, p, data_len);
     *data_sz = data_len;
@@ -337,7 +337,7 @@ int QuicShm::deleteItem(void *hash_ctx, const void *key, unsigned key_sz)
     struct lsquic_shared_hash_if *pInternalShi = QuicShm::getInstance().getInternalShi();
     void *pInternalShiCtx = QuicShm::getInstance().getInternalShiCtx();
     pInternalShi->shi_delete(pInternalShiCtx, key, key_sz);
-    
+
     LsShmHash *pHash = (LsShmHash *)hash_ctx;
     ls_strpair_t parms;
     ls_str_set(&parms.key, (char *)key, key_sz);
@@ -361,7 +361,7 @@ pid_t QuicShm::lookupCidPid(const lsquic_cid_t *cid, ShmCidPidInfo *pInfo)
     ls_str_set(&parms.key, (char *) cid->idbuf, cid->len);
     LsShmHash::iteroffset iterOff;
     LsShmHash::iterator iter;
-    
+
     iterOff = m_pCidMap->findIterator(&parms);
     if (iterOff.m_iOffset == 0)
     {
@@ -392,7 +392,7 @@ pid_t QuicShm::lookupCidPid(const lsquic_cid_t *cid, ShmCidPidInfo *pInfo)
         assert(iter);
 
         memcpy(&pid, iter->getVal(), sizeof(pid));
-        if (pid > 0 && iter->getLruLasttime() != DateTime::s_curTime) 
+        if (pid > 0 && iter->getLruLasttime() != DateTime::s_curTime)
         {
             LS_DBG_LC("[QuicShm::lookupCidPid]: update LRU for CID: %" CID_FMT,
                      CID_BITS(cid));
@@ -435,7 +435,7 @@ void QuicShm::lookupCidPids(const lsquic_cid_t *cids, ShmCidPidInfo *pids,
 }
 
 
-void QuicShm::markBadCidItems(const lsquic_cid_t *cids, unsigned count, 
+void QuicShm::markBadCidItems(const lsquic_cid_t *cids, unsigned count,
                               pid_t pid)
 {
     LsShmHash::iteroffset iterOff;
@@ -457,7 +457,7 @@ void QuicShm::markBadCidItems(const lsquic_cid_t *cids, unsigned count,
 
             assert(iter->getValLen() == sizeof(pid_t));
             memcpy(iter->getVal(), &pid, sizeof(pid_t));
-            if (iter->getLruLasttime() != DateTime::s_curTime) 
+            if (iter->getLruLasttime() != DateTime::s_curTime)
                 m_pCidMap->touchLru(iterOff);
         }
     }
@@ -742,7 +742,7 @@ QuicShm::getNewPacketBuffer()
     packet_buf->qpb_off = offset;
     packet_buf->prev_offset = 0;
     packet_buf->next_offset = 0;
-    LS_DBG_L("[PID: %d] [QuicShm::getNewPacketBuffer] offset %d, packet %p", 
+    LS_DBG_L("[PID: %d] [QuicShm::getNewPacketBuffer] offset %d, packet %p",
              s_pid, offset, packet_buf);
     return packet_buf;
 }
@@ -887,7 +887,7 @@ QuicShm::getPidInfo(pid_t pid, QuicShm::PidInfo &info,
         LS_DBG_H("%s: pid %d not found", __func__, pid);
         return GPIS_NOT_FOUND;
     }
-    
+
     iter = m_pPidPacketOffsetMap->offset2iterator(iterOff);
     assert(iter);
     if (iter)
@@ -937,7 +937,7 @@ QuicShm::removeFromFreeQueue(packet_buf_t *packetBuf)
     LS_DBG_M("[PID: %d] removeFromFreeQueue packet %u (prev: %u, next: %u). "
         , s_pid, packetBuf->qpb_off,
         packetBuf->prev_offset, packetBuf->next_offset);
- 
+
     if (packetBuf->prev_offset)
         prevPacketBuf = packetOffset2ptr(packetBuf->prev_offset);
     else
@@ -995,7 +995,7 @@ QuicShm::removeFromFreeQueue(packet_buf_t *packetBuf)
 enum QuicShm::atpq
 QuicShm::appendToPendQueue(pid_t pid, struct quicshm_packet_buf *packet_buf,
                             time_t now)
-{    
+{
     QuicShm::PidInfo info;
     packet_buf_t *last_buf;
     LsShmHash::iterator iter;
@@ -1078,7 +1078,7 @@ QuicShm::appendToPendQueue(pid_t pid, struct quicshm_packet_buf *packet_buf,
 int
 QuicShm::appendPacketsToFreeQueue(struct quicshm_packet_buf *begin,
                                   struct quicshm_packet_buf *end)
-{    
+{
     QuicShm::PidInfo info;
     packet_buf_t *last_buf;
 
@@ -1224,7 +1224,7 @@ QuicShm::popFirstPendingOffset(pid_t pid)
     QuicShm::PidInfo info;
     LsShmOffset_t retvalOffset;
     LsShmHash::iterator iter;
-    
+
     retvalOffset = 0;
     m_pPidPacketOffsetMap->lock();
     if (getPidInfo(pid, info, iter) != GPIS_FOUND)
@@ -1304,7 +1304,7 @@ void QuicShm::cleanupPidShm(pid_t pid)
     LsShmHash::iterator iter;
     GpiStatus status;
 
-    LS_DBG_L("[PID %d] [QuicShm::cleanupPidShm] cleaning up after pid %d%s", 
+    LS_DBG_L("[PID %d] [QuicShm::cleanupPidShm] cleaning up after pid %d%s",
              s_pid, pid, pid == s_pid ? " (ourselves)" : "");
 
     m_pPidPacketOffsetMap->lock();

--- a/src/quic/quicshm.h
+++ b/src/quic/quicshm.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quicstream.cpp
+++ b/src/quic/quicstream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/quicstream.h
+++ b/src/quic/quicstream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/udplistener.cpp
+++ b/src/quic/udplistener.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/udplistener.h
+++ b/src/quic/udplistener.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/quic/udpspoof.h
+++ b/src/quic/udpspoof.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -50,8 +50,8 @@ struct udpheader {
 
 struct sockaddr;
 rawsock_t init_rawsock();
-int send_udp_spoof( rawsock_t sd, char * raw_sock_buf, int buf_size, 
-            unsigned int src_ip, unsigned int dst_ip, 
+int send_udp_spoof( rawsock_t sd, char * raw_sock_buf, int buf_size,
+            unsigned int src_ip, unsigned int dst_ip,
             unsigned short int src_port, unsigned short int dst_port,
             unsigned short ip_id );
 

--- a/src/socket/coresocket.cpp
+++ b/src/socket/coresocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -104,7 +104,7 @@ int  CoreSocket::connect(const GSockAddr &server, int iFLTag, int *fd,
     {
         errno = EINVAL;
         return -1;
-    }    
+    }
 #if !defined(_USE_F_STACK) || !(defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__))
     if (user)
     {
@@ -119,19 +119,19 @@ int  CoreSocket::connect(const GSockAddr &server, int iFLTag, int *fd,
     if (server.len() < 16)
         return -1;
 
-#ifdef _USE_F_STACK    
+#ifdef _USE_F_STACK
     if (user)
         *fd = ls_socket_fstack(server.family(), type, 0);
     else
-#endif        
+#endif
         *fd = ::socket(server.family(), type, 0);
-    
+
     if (*fd == -1)
         return -1;
     if ((iFLTag) && !user)
         ::fcntl(*fd, F_SETFL, iFLTag);
 
-#ifdef _USE_F_STACK    
+#ifdef _USE_F_STACK
     if (user)
     {
         int on = 1;
@@ -215,7 +215,7 @@ int CoreSocket::listen(const GSockAddr &server, int backLog, int *fd,
         errno = EINVAL;
         return -1;
     }
-#endif    
+#endif
     ret = bind(server, SOCK_STREAM, fd, flag);
     if (ret)
         return ret;
@@ -240,7 +240,7 @@ int CoreSocket::listen(const GSockAddr &server, int backLog, int *fd,
             ls_setsockopt(*fd, IPPROTO_TCP, TCP_FASTOPEN, &val, sizeof(int));
         }
 #endif
-        
+
     }
 
     ret = ls_listen(*fd, backLog);
@@ -255,7 +255,7 @@ int CoreSocket::listen(const GSockAddr &server, int backLog, int *fd,
 }
 
 
-int CoreSocket::bind(const GSockAddr &server, int type, int *fd, 
+int CoreSocket::bind(const GSockAddr &server, int type, int *fd,
                      int flag)
 {
     int ret;
@@ -286,7 +286,7 @@ int CoreSocket::bind(const GSockAddr &server, int type, int *fd,
         && ls_setsockopt(*fd, SOL_SOCKET, SO_REUSEPORT,
                       (char *)(&val), sizeof(val)) != 0)
         goto ERROR;
-#if defined(IPV6_V6ONLY) 
+#if defined(IPV6_V6ONLY)
     if (!(flag & LS_SOCK_USERSOCKET) &&
         server.family() == AF_INET6
         && IN6_IS_ADDR_UNSPECIFIED(&(server.getV6()->sin6_addr)))
@@ -342,10 +342,10 @@ int CoreSocket::close()
 int CoreSocket::enableFastOpen(int fd, int queLen)
 {
     int ret = 1;
-#ifdef _USE_F_STACK    
+#ifdef _USE_F_STACK
     if (is_usersock(fd))
         return -1;
-#endif    
+#endif
 #if defined(linux) || defined(__linux) || defined(__linux__)
 #ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN 23
@@ -353,7 +353,7 @@ int CoreSocket::enableFastOpen(int fd, int queLen)
     static int isTfoAvail = 1;
     if (!isTfoAvail)
         return -1;
-    
+
     ret = ls_setsockopt(fd, SOL_TCP, TCP_FASTOPEN, &queLen, sizeof(queLen));
     if ((ret == -1)&&(errno == ENOPROTOOPT))
         isTfoAvail = 0;

--- a/src/socket/coresocket.h
+++ b/src/socket/coresocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -32,11 +32,11 @@
 
 #define INVALID_FD  -1
 
-/* These two flags can be specified in the 'nodelay' option of listen or 
+/* These two flags can be specified in the 'nodelay' option of listen or
  * connect.  They can be combined.  Note that if LS_SOCK_USERSOCKET is
  * specified, it is automatically non-blocking, so be ready for that.  */
-/* User socket "connect" note: if the connect fails with an errno of 
- * EINPROGRESS you will need to return control to the event loop and 
+/* User socket "connect" note: if the connect fails with an errno of
+ * EINPROGRESS you will need to return control to the event loop and
  * complete the function by calling connect_finish().  */
 #define LS_SOCK_NODELAY         1
 #define LS_SOCK_USERSOCKET      2
@@ -106,7 +106,7 @@ public:
     /* connect_finish is only used for user-land sockets and is only required
      * if the connect returns -1 with errno == EINPROGRESS */
     static int  connect_finish(int fd);
-    static int  bind(const GSockAddr &server, int type, int *fd, 
+    static int  bind(const GSockAddr &server, int type, int *fd,
                      int flag = 0);
     static int  listen(const char *pURL, int backlog, int *fd,
                        int flag = LS_SOCK_NODELAY,
@@ -141,7 +141,7 @@ public:
         return ls_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(int));
 //#endif
     }
-    
+
     static int enableFastOpen(int fd, int queLen);
 
     static void setIpv6Only(int only);

--- a/src/socket/datagramsocket.cpp
+++ b/src/socket/datagramsocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/datagramsocket.h
+++ b/src/socket/datagramsocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/errorno.cpp
+++ b/src/socket/errorno.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/errorno.h
+++ b/src/socket/errorno.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/filecntl.cpp
+++ b/src/socket/filecntl.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/filecntl.h
+++ b/src/socket/filecntl.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/gsockaddr.cpp
+++ b/src/socket/gsockaddr.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/gsockaddr.h
+++ b/src/socket/gsockaddr.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/hostinfo.cpp
+++ b/src/socket/hostinfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/hostinfo.h
+++ b/src/socket/hostinfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/ipv4addr.cpp
+++ b/src/socket/ipv4addr.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/ipv4addr.h
+++ b/src/socket/ipv4addr.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/ls_sock.h
+++ b/src/socket/ls_sock.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -23,12 +23,12 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" {
 #endif
 /**
  * @file ls_sock.h
- * @brief Include file for library which allows you to use both native and 
+ * @brief Include file for library which allows you to use both native and
  * user-land sockets with the same basic API (some minor changes, see below).
  */
 
@@ -43,8 +43,8 @@ extern "C" {
  */
 
 /**
- * @def _USE_USER_SOCK       
- * @brief If defined, then user-land sockets are enabled.  
+ * @def _USE_USER_SOCK
+ * @brief If defined, then user-land sockets are enabled.
  */
 
 #ifdef _USE_USER_SOCK
@@ -55,7 +55,7 @@ extern "C" {
 #define ls_sock_init(a,b,c)
 #define ls_run(a,b)         while (1) a(b)
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 #define ls_bind(a,b,c)      ::bind(a,b,c)
 #define ls_connect(a,b,c)   ::connect(a,b,c)
 #define is_usersock(sockfd) 0

--- a/src/socket/rawsocket.cpp
+++ b/src/socket/rawsocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/rawsocket.h
+++ b/src/socket/rawsocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/serversocket.cpp
+++ b/src/socket/serversocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/serversocket.h
+++ b/src/socket/serversocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/sockdef.h
+++ b/src/socket/sockdef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/streamsocket.cpp
+++ b/src/socket/streamsocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/streamsocket.h
+++ b/src/socket/streamsocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpconnection.cpp
+++ b/src/socket/tcpconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpconnection.h
+++ b/src/socket/tcpconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpserversocket.cpp
+++ b/src/socket/tcpserversocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpserversocket.h
+++ b/src/socket/tcpserversocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpsockopt.cpp
+++ b/src/socket/tcpsockopt.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/tcpsockopt.h
+++ b/src/socket/tcpsockopt.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/udpsocket.cpp
+++ b/src/socket/udpsocket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/socket/udpsocket.h
+++ b/src/socket/udpsocket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/protocoldef.h
+++ b/src/spdy/protocoldef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyconnection.cpp
+++ b/src/spdy/spdyconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyconnection.h
+++ b/src/spdy/spdyconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdydebug.cpp
+++ b/src/spdy/spdydebug.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdydebug.h
+++ b/src/spdy/spdydebug.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyprotocol.cpp
+++ b/src/spdy/spdyprotocol.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyprotocol.h
+++ b/src/spdy/spdyprotocol.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdystream.cpp
+++ b/src/spdy/spdystream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdystream.h
+++ b/src/spdy/spdystream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdystreampool.cpp
+++ b/src/spdy/spdystreampool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdystreampool.h
+++ b/src/spdy/spdystreampool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyzlibfilter.cpp
+++ b/src/spdy/spdyzlibfilter.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/spdy/spdyzlibfilter.h
+++ b/src/spdy/spdyzlibfilter.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiconfig.cpp
+++ b/src/ssi/ssiconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiconfig.h
+++ b/src/ssi/ssiconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiengine.cpp
+++ b/src/ssi/ssiengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiengine.h
+++ b/src/ssi/ssiengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiruntime.cpp
+++ b/src/ssi/ssiruntime.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiruntime.h
+++ b/src/ssi/ssiruntime.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiscript.cpp
+++ b/src/ssi/ssiscript.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/ssi/ssiscript.h
+++ b/src/ssi/ssiscript.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/hiocrypto.h
+++ b/src/sslpp/hiocrypto.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -35,7 +35,7 @@ public:
     };
     HioCrypto()             {}
     virtual ~HioCrypto()    {}
-    
+
     virtual int getEnv(HioCrypto::ENV id, char *&val,int maxValLen) = 0;
     virtual X509 *getPeerCertificate() const
     {   return NULL;    }
@@ -45,7 +45,7 @@ public:
     {   return 0;       }
     int  buildVerifyErrorString(char *pBuf, int len) const
     {   return 0;       }
-    
+
 };
 
 

--- a/src/sslpp/ls_fdbuf_bio.c
+++ b/src/sslpp/ls_fdbuf_bio.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/ls_fdbuf_bio.h
+++ b/src/sslpp/ls_fdbuf_bio.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -21,7 +21,7 @@
 
 #include <lsdef.h>
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -55,16 +55,16 @@ enum LS_FDBIO_FLAG
 };
 
 /**
- * @brief ls_fdbuf_bio_init called during the connection constructor, 
+ * @brief ls_fdbuf_bio_init called during the connection constructor,
  * initializes the BIO access.
- * @param[out] fdbio is initialized for later use.                             
+ * @param[out] fdbio is initialized for later use.
  * @return None.
  */
 void ls_fdbuf_bio_init(ls_fdbio_data *fdbio);
 
 
 /**
- * @brief ls_fdbio_create initializes the use of BIOs.  Call once per 
+ * @brief ls_fdbio_create initializes the use of BIOs.  Call once per
  * connection.
  * @param[in] fd The socket fd for the connection.
  * @param[out] fdbio ls_fdbuf_bio to be used as the BIO for the connection.
@@ -112,7 +112,7 @@ ls_inline int ls_fdbio_is_wblock(ls_fdbio_data *fdbio)
 ls_inline void ls_fdbio_clear_wblock(ls_fdbio_data *fdbio)
 {    fdbio->m_flag &= ~LS_FDBIO_WBLOCK;    }
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/sslpp/ocsp/ocsp.c
+++ b/src/sslpp/ocsp/ocsp.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/ocsp/ocsp.h
+++ b/src/sslpp/ocsp/ocsp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslasyncpk.cpp
+++ b/src/sslpp/sslasyncpk.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -78,16 +78,16 @@ static ssl_private_key_result_t AsyncPrivateKeyDecrypt(
 static ssl_private_key_result_t AsyncPrivateKeyComplete(
     SSL *ssl, uint8_t *out, size_t *out_len, size_t max_out);
 
-static const SSL_PRIVATE_KEY_METHOD s_async_private_key_method = 
+static const SSL_PRIVATE_KEY_METHOD s_async_private_key_method =
     { AsyncPrivateKeySign, AsyncPrivateKeyDecrypt, AsyncPrivateKeyComplete };
 
 
 static ssl_private_key_result_t AsyncPrivateKeySign(
-    SSL* ssl, uint8_t* out, size_t* out_len, size_t max_out, 
+    SSL* ssl, uint8_t* out, size_t* out_len, size_t max_out,
     uint16_t signature_algorithm, const uint8_t* in, size_t in_len)
 {
     ssl_apk_offload_t *data = (ssl_apk_offload_t *)SSL_get_ex_data(ssl, s_ssl_apk_index);
-    
+
     if (!data)
     {
         DEBUG_MESSAGE("[SSL: %p] AsyncPrivateKeySign method not defined\n", ssl);
@@ -128,7 +128,7 @@ static ssl_private_key_result_t AsyncPrivateKeySign(
         ERROR_MESSAGE("[SSL: %p] AsyncPrivateKeySign unable to allocate memory:"
                       " %ld bytes\n", ssl, in_len + max_out);
         return ssl_private_key_failure;
-    }    
+    }
     data->m_in = (uint8_t *)data->m_sign + max_out;
     memcpy(data->m_in, in, in_len);
     data->m_in_len = in_len;
@@ -153,8 +153,8 @@ static ssl_private_key_result_t AsyncPrivateKeySign(
 }
 
 
-static ssl_private_key_result_t AsyncPrivateKeyComplete(SSL *ssl, 
-    uint8_t *out, size_t *out_len, size_t max_out) 
+static ssl_private_key_result_t AsyncPrivateKeyComplete(SSL *ssl,
+    uint8_t *out, size_t *out_len, size_t max_out)
 {
     ssl_apk_offload_t *data = (ssl_apk_offload_t *)SSL_get_ex_data(ssl, s_ssl_apk_index);
 

--- a/src/sslpp/sslasyncpk.h
+++ b/src/sslpp/sslasyncpk.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslcert.cpp
+++ b/src/sslpp/sslcert.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslcert.h
+++ b/src/sslpp/sslcert.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslcertcomp.cpp
+++ b/src/sslpp/sslcertcomp.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -68,7 +68,7 @@ static bool s_activate_decomp = false;
 static int  s_iBrCompressLevel = 6;
 static int  s_iSSL_CTX_index = -1;
 
-static void freeCtxData(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, 
+static void freeCtxData(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
                         long argl, void *argp)
 {
     assert(idx == s_iSSL_CTX_index);
@@ -80,8 +80,8 @@ static void freeCtxData(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
 }
 
 
-static SslCertComp::comp_cache_t *cache_data(SSL_CTX *ctx, 
-                                             SslCertComp::comp_cache_t *cache, 
+static SslCertComp::comp_cache_t *cache_data(SSL_CTX *ctx,
+                                             SslCertComp::comp_cache_t *cache,
                                              int in_size,
                                              char *readBuffer, size_t len)
 {
@@ -92,41 +92,41 @@ static SslCertComp::comp_cache_t *cache_data(SSL_CTX *ctx,
             return NULL;
         cache->m_input_len = in_size;
         cache->m_len = len;
-        memcpy(cache->m_comp, readBuffer, len);    
+        memcpy(cache->m_comp, readBuffer, len);
     }
     else
     {
         SslCertComp::comp_cache_t *recache;
-        recache = (SslCertComp::comp_cache_t *)ls_prealloc(cache, cache->m_len + 
+        recache = (SslCertComp::comp_cache_t *)ls_prealloc(cache, cache->m_len +
                                                            sizeof(int) * 2 + len);
         if (recache)
         {
             memcpy(&recache->m_comp[recache->m_len], readBuffer, len);
-            recache->m_len += len;    
+            recache->m_len += len;
             cache = recache;
         }
-        else 
+        else
         {
             return NULL;
-        }    
+        }
     }
     SSL_CTX_set_ex_data(ctx, s_iSSL_CTX_index, (void *)cache);
     return cache;
 }
 
 
-static int certCompressFunc(SSL *ssl, CBB *out, const uint8_t *in_data, 
-                            size_t in_size, 
-#ifdef ZBUF_H                            
-                            Zbuf *zbuf, 
+static int certCompressFunc(SSL *ssl, CBB *out, const uint8_t *in_data,
+                            size_t in_size,
+#ifdef ZBUF_H
+                            Zbuf *zbuf,
 #else
                             Compressor *zbuf,
-#endif                            
+#endif
                             int level)
 {
     DEBUG_MESSAGE("[SSLCertComp] Compressing %ld bytes\n", in_size);
     SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
-    
+
     SslCertComp::comp_cache_t *cache;
     cache = (SslCertComp::comp_cache_t *)SSL_CTX_get_ex_data(ctx, s_iSSL_CTX_index);
     if (cache)
@@ -149,15 +149,15 @@ static int certCompressFunc(SSL *ssl, CBB *out, const uint8_t *in_data,
             cache = NULL;
         }
     }
-    
+
     VMemBuf   vmembuf;
-    
-    if (vmembuf.set(VMBUF_MALLOC, 
-#ifdef ZBUF_H                            
+
+    if (vmembuf.set(VMBUF_MALLOC,
+#ifdef ZBUF_H
                     in_size
 #else
                     (int)in_size
-#endif                    
+#endif
                    ) == LS_FAIL)
     {
         ERROR_MESSAGE("[SSLCertComp] Unable to set memory buffer\n");
@@ -165,15 +165,15 @@ static int certCompressFunc(SSL *ssl, CBB *out, const uint8_t *in_data,
     }
     zbuf->setCompressCache(&vmembuf);
     if (zbuf->init(
-#ifdef ZBUF_H                            
-                   Zbuf::MODE_COMPRESS, 
+#ifdef ZBUF_H
+                   Zbuf::MODE_COMPRESS,
 #else
                    Compressor::COMPRESSOR_COMPRESS,
-#endif                   
+#endif
                    level
-#ifdef ZBUF_H                            
+#ifdef ZBUF_H
                    , 0
-#endif                   
+#endif
                   ) == LS_FAIL)
     {
         ERROR_MESSAGE("[SSLCertComp] Unable to initialize compression\n");
@@ -220,7 +220,7 @@ static int certCompressFunc(SSL *ssl, CBB *out, const uint8_t *in_data,
 }
 
 
-static int certCompressFuncBrotli(SSL *ssl, CBB *out, const uint8_t *in, 
+static int certCompressFuncBrotli(SSL *ssl, CBB *out, const uint8_t *in,
                                   size_t in_len)
 {
     BrotliBuf brotBuf;
@@ -229,26 +229,26 @@ static int certCompressFuncBrotli(SSL *ssl, CBB *out, const uint8_t *in,
 
 
 static int certDecompressFunc(SSL *ssl, CRYPTO_BUFFER **out,
-                              size_t uncompressed_len, const uint8_t *in, 
+                              size_t uncompressed_len, const uint8_t *in,
                               size_t in_len,
-#ifdef ZBUF_H                            
-                              Zbuf *zbuf, 
+#ifdef ZBUF_H
+                              Zbuf *zbuf,
 #else
                               Compressor *zbuf,
-#endif                            
+#endif
                               int level)
 {
     DEBUG_MESSAGE("[SSLCertComp] Decompressing %ld bytes to %ld bytes\n", in_len,
                   uncompressed_len);
 
     VMemBuf   vmembuf;
-    
-    if (vmembuf.set(VMBUF_MALLOC, 
-#ifdef ZBUF_H                            
+
+    if (vmembuf.set(VMBUF_MALLOC,
+#ifdef ZBUF_H
                     in_len
 #else
                     (int)in_len
-#endif                    
+#endif
                    ) == LS_FAIL)
     {
         ERROR_MESSAGE("[SSLCertComp] Decompress Unable to set memory buffer\n");
@@ -256,15 +256,15 @@ static int certDecompressFunc(SSL *ssl, CRYPTO_BUFFER **out,
     }
     zbuf->setCompressCache(&vmembuf);
     if (zbuf->init(
-#ifdef ZBUF_H                            
-                   Zbuf::MODE_DECOMPRESS, 
+#ifdef ZBUF_H
+                   Zbuf::MODE_DECOMPRESS,
 #else
                    Compressor::COMPRESSOR_DECOMPRESS,
-#endif                   
+#endif
                    level
-#ifdef ZBUF_H                            
+#ifdef ZBUF_H
                    , 0
-#endif                   
+#endif
                   ) == LS_FAIL)
     {
         ERROR_MESSAGE("[SSLCertComp] Unable to initialize decompression\n");
@@ -323,7 +323,7 @@ static int certDecompressFunc(SSL *ssl, CRYPTO_BUFFER **out,
 
 
 static int certDecompressFuncBrotli(SSL *ssl, CRYPTO_BUFFER **out,
-                                    size_t uncompressed_len, const uint8_t *in, 
+                                    size_t uncompressed_len, const uint8_t *in,
                                     size_t in_len)
 {
     BrotliBuf brotBuf;
@@ -342,26 +342,26 @@ SslCertComp::~SslCertComp()
 
 
 void SslCertComp::activateComp(bool activate)
-{   
+{
     DEBUG_MESSAGE("[SSLCertComp] %sactivating compression!\n", activate ? "" : "de");
-    s_activate_comp = activate;  
+    s_activate_comp = activate;
     if ((activate) && (s_iSSL_CTX_index < 0))
         s_iSSL_CTX_index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, freeCtxData);
 }
 
 
 void SslCertComp::activateDecomp(bool activate)
-{   
+{
     DEBUG_MESSAGE("[SSLCertComp] %sactivating decompression!\n", activate ? "" : "de");
-    s_activate_decomp = activate;  
+    s_activate_decomp = activate;
     if ((activate) && (s_iSSL_CTX_index < 0))
         s_iSSL_CTX_index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, freeCtxData);
 }
 
 
 void SslCertComp::setBrCompressLevel(int level)
-{ 
-    s_iBrCompressLevel = level; 
+{
+    s_iBrCompressLevel = level;
 }
 
 
@@ -376,7 +376,7 @@ void SslCertComp::enableCertComp(SSL_CTX *ctx)
     {
         if (s_iSSL_CTX_index < 0)
             s_iSSL_CTX_index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, freeCtxData);
-        
+
         if (!(SSL_CTX_add_cert_compression_alg(ctx, TLSEXT_cert_compression_brotli,
                                                certCompressFuncBrotli, NULL)))
             INFO_MESSAGE("[SSL_CTX:%p] Requested cert compression but unable to "
@@ -388,7 +388,7 @@ void SslCertComp::enableCertComp(SSL_CTX *ctx)
         DEBUG_MESSAGE("[SSL_CTX:%p] Cert compression not enabled\n", ctx);
 }
 
-    
+
 void SslCertComp::enableCertDecomp(SSL_CTX *ctx)
 {
     DEBUG_MESSAGE("[SSLCertComp] enableCertDecomp: %p\n", ctx);
@@ -396,7 +396,7 @@ void SslCertComp::enableCertDecomp(SSL_CTX *ctx)
     {
         if (s_iSSL_CTX_index < 0)
             s_iSSL_CTX_index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, freeCtxData);
-        
+
         if (!(SSL_CTX_add_cert_compression_alg(ctx, TLSEXT_cert_compression_brotli,
                                                NULL, certDecompressFuncBrotli)))
             INFO_MESSAGE("[SSLCertComp] Requested cert decompression but unable to "
@@ -406,5 +406,5 @@ void SslCertComp::enableCertDecomp(SSL_CTX *ctx)
         DEBUG_MESSAGE("[SSLCertComp] Cert decompression not enabled\n");
 }
 
-    
+
 #endif // SSLCERTCOMP

--- a/src/sslpp/sslcertcomp.h
+++ b/src/sslpp/sslcertcomp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -30,20 +30,20 @@
 
 #include <lsdef.h>
 
-class SslCertComp 
+class SslCertComp
 {
-    SslCertComp(); 
+    SslCertComp();
     ~SslCertComp();
-    
+
 public:
-    typedef struct 
+    typedef struct
     {
         int     m_input_len;
         int     m_len;
         uint8_t m_comp[1];
     } comp_cache_t;
-    
-    static void activateComp(bool activate);      
+
+    static void activateComp(bool activate);
     static void activateDecomp(bool activate);
     static void enableCertComp(SSL_CTX *ctx);
     static void enableCertDecomp(SSL_CTX *ctx);

--- a/src/sslpp/sslconnection.cpp
+++ b/src/sslpp/sslconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -202,7 +202,7 @@ int SslConnection::writev(const struct iovec *vect, int count,
     char *pBufEnd;
     char *pCurEnd;
     char achBuf[4096];
-    
+
     pBufEnd = achBuf + 4096;
     pCurEnd = achBuf;
     for (; vect < pEnd ;)
@@ -271,7 +271,7 @@ int SslConnection::flush()
 int SslConnection::shutdown(int bidirectional)
 {
     assert(m_ssl);
-    
+
     m_flag = 0;
     if (m_iStatus == ACCEPTING)
     {
@@ -319,7 +319,7 @@ int SslConnection::accept()
                       this);
         return -1;
     }
-    DEBUG_MESSAGE("[SSL: %p] Call SSL_do_handshake, ssl: %p, ctx: %p\n", this, 
+    DEBUG_MESSAGE("[SSL: %p] Call SSL_do_handshake, ssl: %p, ctx: %p\n", this,
                   m_ssl, SSL_get_SSL_CTX(m_ssl));
     setFlag(F_ASYNC_PK, 0);
     ret = SSL_do_handshake(m_ssl);
@@ -474,7 +474,7 @@ int SslConnection::connect()
 
 
 int SslConnection::tryagain()
-{    
+{
     DEBUG_MESSAGE("[SSL: %p] tryagain!\n", this);
     assert(m_ssl);
     switch (m_iStatus)
@@ -547,7 +547,7 @@ int SslConnection::getSpdyVersion()
     int v = 0;
 
     DEBUG_MESSAGE("[SSL: %p] getSpdyVersion\n", this);
-    
+
 #ifdef LS_ENABLE_SPDY
     unsigned int             len = 0;
     const unsigned char     *data = NULL;

--- a/src/sslpp/sslconnection.h
+++ b/src/sslpp/sslconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -127,7 +127,7 @@ public:
     int getAlpnResult()     {   return getSpdyVersion();    }
 
     int updateOnGotCert();
-    
+
     void enableRbio() {};
 
     static void initConnIdx();
@@ -136,7 +136,7 @@ public:
 
     static int getCipherBits(const SSL_CIPHER *pCipher, int *algkeysize);
     static int isClientVerifyOptional(int i);
-    
+
     // Can only be called after the first failed accept or read, to obtain the
     // raw data which can be used in a redirect (see ntwkiolink.cpp).
     char *getRawBuffer(int *len);

--- a/src/sslpp/sslcontext.cpp
+++ b/src/sslpp/sslcontext.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -67,7 +67,7 @@ SslContext *SslContext::config(SslContext *pContext, const char *pZcDomainName,
             LS_DBG_L("[SSL] Insufficient memory\n");
             return NULL;
         }
-        
+
         if (pNewContext->init())
             return NULL;
 
@@ -648,7 +648,7 @@ int SslContext::init(int iMethod)
         return 0;
     if (initSSL())
         return -1;
-    
+
     m_iMethod = iMethod;
     m_iEnableSpdy = 0;
     m_iEnableOcsp = 0;
@@ -695,7 +695,7 @@ void SslContext::release()
 {
 #ifdef SSLCERTCOMP
     SslCertComp::disableCertCompDecomp(m_pCtx);
-#endif        
+#endif
     if (m_pCtx != NULL && m_pCtx != SSL_CTX_PENDING)
     {
         SSL_CTX *pCtx = m_pCtx;

--- a/src/sslpp/sslcontext.h
+++ b/src/sslpp/sslcontext.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslcontextconfig.cpp
+++ b/src/sslpp/sslcontextconfig.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslcontextconfig.h
+++ b/src/sslpp/sslcontextconfig.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/ssldef.h
+++ b/src/sslpp/ssldef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslengine.cpp
+++ b/src/sslpp/sslengine.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslengine.h
+++ b/src/sslpp/sslengine.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslerror.cpp
+++ b/src/sslpp/sslerror.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslerror.h
+++ b/src/sslpp/sslerror.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslsesscache.cpp
+++ b/src/sslpp/sslsesscache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslsesscache.h
+++ b/src/sslpp/sslsesscache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslticket.cpp
+++ b/src/sslpp/sslticket.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -161,8 +161,8 @@ int SslTicket::initShm(int uid, int gid)
         LOGDBG("Open LsShm Failed.");
         return LS_FAIL;
     }
-    pShm->chperm(uid, gid, 0600);   
-    
+    pShm->chperm(uid, gid, 0600);
+
     if ((pShmPool = pShm->getGlobalPool()) == NULL)
     {
         LOGDBG("Get Global Pool Failed.");
@@ -238,13 +238,13 @@ int SslTicket::init(const char* pFileName, long int timeout, int uid, int gid)
             return LS_FAIL;
         }
         pShmData = (STShmData_t *)m_pKeyStore->offset2ptr(m_iOff);
-        memmove(&pShmData->m_keys, &m_keys, sizeof(m_keys) ); 
+        memmove(&pShmData->m_keys, &m_keys, sizeof(m_keys) );
         pShmData->m_tmLastAccess = DateTime::s_curTime;
         m_pKeyStore->unlock();
         return LS_OK;
     }
     pShmData = (STShmData_t *)m_pKeyStore->offset2ptr(m_iOff);
-    memmove(&m_keys, &pShmData->m_keys, sizeof(m_keys) ); 
+    memmove(&m_keys, &pShmData->m_keys, sizeof(m_keys) );
     m_pKeyStore->unlock();
     pCur = &m_keys.m_aKeys[m_keys.m_idxCur];
     if (pCur->expireSec > (DateTime::s_curTime + (timeout >> 1)))
@@ -255,7 +255,7 @@ int SslTicket::init(const char* pFileName, long int timeout, int uid, int gid)
         m_pKeyStore->lock();
         pShmData = (STShmData_t *)m_pKeyStore->offset2ptr(m_iOff);
         checkShmExpire(pShmData);
-        memmove(&m_keys, &pShmData->m_keys, sizeof(m_keys) ); 
+        memmove(&m_keys, &pShmData->m_keys, sizeof(m_keys) );
         m_pKeyStore->unlock();
         return LS_OK;
     }
@@ -285,7 +285,7 @@ int SslTicket::init(const char* pFileName, long int timeout, int uid, int gid)
         memmove(&m_keys.m_aKeys[m_keys.m_idxCur], &newKey, SSLTICKET_KEYSIZE);
         m_pKeyStore->lock();
         pShmData = (STShmData_t *)m_pKeyStore->offset2ptr(m_iOff);
-        memmove(&pShmData->m_keys, &m_keys, sizeof(m_keys) ); 
+        memmove(&pShmData->m_keys, &m_keys, sizeof(m_keys) );
     }
     m_keys.m_aKeys[m_keys.m_idxCur].expireSec = DateTime::s_curTime + timeout;
     pShmData->m_keys.m_aKeys[pShmData->m_keys.m_idxCur].expireSec
@@ -401,7 +401,7 @@ int SslTicket::checkShmExpire(STShmData_t *pShmData)
 
     RAND_bytes((unsigned char *)pPrev, SSLTICKET_KEYSIZE);
     pPrev->expireSec = pNext->expireSec + (m_iLifetime >> 1);
-    rotateIndices(pShmData->m_keys.m_idxPrev, pShmData->m_keys.m_idxCur, 
+    rotateIndices(pShmData->m_keys.m_idxPrev, pShmData->m_keys.m_idxCur,
                   pShmData->m_keys.m_idxNext);
     return LS_OK;
 }

--- a/src/sslpp/sslticket.h
+++ b/src/sslpp/sslticket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -49,7 +49,7 @@ typedef struct rotatkeys_s
     short         m_idxNext;
 } RotateKeys_t;
 
-class SslTicket 
+class SslTicket
 {
     static LsShmHash      *m_pKeyStore;
     static AutoStr2       *m_pFile;

--- a/src/sslpp/sslutil.cpp
+++ b/src/sslpp/sslutil.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/sslpp/sslutil.h
+++ b/src/sslpp/sslutil.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/crewworker.cpp
+++ b/src/thread/crewworker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/crewworker.h
+++ b/src/thread/crewworker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -40,12 +40,12 @@ public:
     void setSlot(int slot)      {   m_slot = slot;  }
 
     const WorkCrew * getWorkCrew() const { return m_wc; }
-    
+
     int start()
     {
         attrSetDetachState(PTHREAD_CREATE_DETACHED);
-        return Worker::start(this); 
-    }        
+        return Worker::start(this);
+    }
 
 protected:
     virtual void thr_cleanup();
@@ -54,7 +54,7 @@ protected:
 private:
     WorkCrew                 *m_wc;
     int32_t                   m_slot;
-    
+
     LS_NO_COPY_ASSIGN(CrewWorker);
 };
 

--- a/src/thread/mtnotifier.cpp
+++ b/src/thread/mtnotifier.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/mtnotifier.h
+++ b/src/thread/mtnotifier.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadcond.cpp
+++ b/src/thread/pthreadcond.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadcond.h
+++ b/src/thread/pthreadcond.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadmutex.cpp
+++ b/src/thread/pthreadmutex.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadmutex.h
+++ b/src/thread/pthreadmutex.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadworkqueue.cpp
+++ b/src/thread/pthreadworkqueue.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/pthreadworkqueue.h
+++ b/src/thread/pthreadworkqueue.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/thread.cpp
+++ b/src/thread/thread.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/workcrew.cpp
+++ b/src/thread/workcrew.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/workcrew.h
+++ b/src/thread/workcrew.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/worker.cpp
+++ b/src/thread/worker.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/thread/worker.h
+++ b/src/thread/worker.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/accesscontrol.cpp
+++ b/src/util/accesscontrol.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/accesscontrol.h
+++ b/src/util/accesscontrol.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/accessdef.h
+++ b/src/util/accessdef.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/aho.h
+++ b/src/util/aho.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -65,7 +65,7 @@ public:
 
     /* search for matches in an aho corasick tree. */
     unsigned int search(AhoState *start_state, const char *string, size_t size,
-                        size_t startpos, size_t *out_start, size_t *out_end, 
+                        size_t startpos, size_t *out_start, size_t *out_end,
                         AhoState **out_last_state, void **pattern_ctx)
     {
         return ls_aho_search(this, start_state, string, size, startpos,

--- a/src/util/autobuf.h
+++ b/src/util/autobuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/autostr.cpp
+++ b/src/util/autostr.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/autostr.h
+++ b/src/util/autostr.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/blockbuf.cpp
+++ b/src/util/blockbuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/blockbuf.h
+++ b/src/util/blockbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/brotlibuf.cpp
+++ b/src/util/brotlibuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/brotlibuf.h
+++ b/src/util/brotlibuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/compressor.cpp
+++ b/src/util/compressor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/compressor.h
+++ b/src/util/compressor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/configentry.cpp
+++ b/src/util/configentry.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/configentry.h
+++ b/src/util/configentry.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/connpool.cpp
+++ b/src/util/connpool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/connpool.h
+++ b/src/util/connpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/crashguard.cpp
+++ b/src/util/crashguard.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/crashguard.h
+++ b/src/util/crashguard.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/daemonize.cpp
+++ b/src/util/daemonize.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -155,13 +155,13 @@ struct passwd *Daemonize::configUserGroup(const char *pUser,
         if (!pw)
             return NULL;
     }
-    
+
     if (!pGroup)
     {
         gid = pw->pw_gid;
         return pw;
     }
-    
+
     struct group *gr;
 
     gr = getgrnam(pGroup);

--- a/src/util/daemonize.h
+++ b/src/util/daemonize.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/datetime.cpp
+++ b/src/util/datetime.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/datetime.h
+++ b/src/util/datetime.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/dlinkqueue.cpp
+++ b/src/util/dlinkqueue.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/dlinkqueue.h
+++ b/src/util/dlinkqueue.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/duplicable.cpp
+++ b/src/util/duplicable.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/duplicable.h
+++ b/src/util/duplicable.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/emailsender.cpp
+++ b/src/util/emailsender.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/emailsender.h
+++ b/src/util/emailsender.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/env.h
+++ b/src/util/env.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/fdpass.cpp
+++ b/src/util/fdpass.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/fdpass.h
+++ b/src/util/fdpass.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/filtermatch.cpp
+++ b/src/util/filtermatch.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/filtermatch.h
+++ b/src/util/filtermatch.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gfactory.cpp
+++ b/src/util/gfactory.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gfactory.h
+++ b/src/util/gfactory.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ghash.cpp
+++ b/src/util/ghash.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ghash.h
+++ b/src/util/ghash.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gmap.h
+++ b/src/util/gmap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gnew.cpp
+++ b/src/util/gnew.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gnew.h
+++ b/src/util/gnew.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gpath.cpp
+++ b/src/util/gpath.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gpath.h
+++ b/src/util/gpath.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gpointerlist.cpp
+++ b/src/util/gpointerlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gpointerlist.h
+++ b/src/util/gpointerlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gsendfile.h
+++ b/src/util/gsendfile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/guardedapp.cpp
+++ b/src/util/guardedapp.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/guardedapp.h
+++ b/src/util/guardedapp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gzipbuf.cpp
+++ b/src/util/gzipbuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/gzipbuf.h
+++ b/src/util/gzipbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/hashdatacache.cpp
+++ b/src/util/hashdatacache.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/hashdatacache.h
+++ b/src/util/hashdatacache.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/hashstringmap.cpp
+++ b/src/util/hashstringmap.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/hashstringmap.h
+++ b/src/util/hashstringmap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/httputil.cpp
+++ b/src/util/httputil.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/httputil.h
+++ b/src/util/httputil.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/iconnection.cpp
+++ b/src/util/iconnection.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/iconnection.h
+++ b/src/util/iconnection.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ienv.h
+++ b/src/util/ienv.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/iovec.cpp
+++ b/src/util/iovec.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/iovec.h
+++ b/src/util/iovec.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/itimer.cpp
+++ b/src/util/itimer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/itimer.h
+++ b/src/util/itimer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/keydata.cpp
+++ b/src/util/keydata.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/keydata.h
+++ b/src/util/keydata.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkedobj.cpp
+++ b/src/util/linkedobj.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkedobj.h
+++ b/src/util/linkedobj.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkedqueue.cpp
+++ b/src/util/linkedqueue.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkedqueue.h
+++ b/src/util/linkedqueue.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkobjpool.cpp
+++ b/src/util/linkobjpool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/linkobjpool.h
+++ b/src/util/linkobjpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/logfile.cpp
+++ b/src/util/logfile.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/logfile.h
+++ b/src/util/logfile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/loopbuf.cpp
+++ b/src/util/loopbuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/loopbuf.h
+++ b/src/util/loopbuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ls_hash_fun.h
+++ b/src/util/ls_hash_fun.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/misc/denydup.h
+++ b/src/util/misc/denydup.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/misc/profiletime.cpp
+++ b/src/util/misc/profiletime.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/misc/profiletime.h
+++ b/src/util/misc/profiletime.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ni_fio.c
+++ b/src/util/ni_fio.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ni_fio.h
+++ b/src/util/ni_fio.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/objarray.h
+++ b/src/util/objarray.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/objpool.cpp
+++ b/src/util/objpool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/objpool.h
+++ b/src/util/objpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pcregex.cpp
+++ b/src/util/pcregex.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pcregex.h
+++ b/src/util/pcregex.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pcutil.cpp
+++ b/src/util/pcutil.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pcutil.h
+++ b/src/util/pcutil.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pidfile.cpp
+++ b/src/util/pidfile.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pidfile.h
+++ b/src/util/pidfile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pool.cpp
+++ b/src/util/pool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/pool.h
+++ b/src/util/pool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/poolalloc.cpp
+++ b/src/util/poolalloc.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/poolalloc.h
+++ b/src/util/poolalloc.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/radixtree.cpp
+++ b/src/util/radixtree.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/radixtree.h
+++ b/src/util/radixtree.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/refcounter.cpp
+++ b/src/util/refcounter.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/refcounter.h
+++ b/src/util/refcounter.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/resourcepool.cpp
+++ b/src/util/resourcepool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/resourcepool.h
+++ b/src/util/resourcepool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/rlimits.cpp
+++ b/src/util/rlimits.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/rlimits.h
+++ b/src/util/rlimits.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/semaphore.cpp
+++ b/src/util/semaphore.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/semaphore.h
+++ b/src/util/semaphore.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/signalutil.cpp
+++ b/src/util/signalutil.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/signalutil.h
+++ b/src/util/signalutil.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/ssnprintf.h
+++ b/src/util/ssnprintf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/staticobj.cpp
+++ b/src/util/staticobj.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/staticobj.h
+++ b/src/util/staticobj.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringlist.cpp
+++ b/src/util/stringlist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringlist.h
+++ b/src/util/stringlist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringmap.cpp
+++ b/src/util/stringmap.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringmap.h
+++ b/src/util/stringmap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringtool.cpp
+++ b/src/util/stringtool.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/stringtool.h
+++ b/src/util/stringtool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -81,7 +81,7 @@ public:
                                   const char *pDelim = NULL, int delimLen = 0);
     static char *memNextArg(char **s, int len, const char *pDelim = NULL,
                             int delimLen = 0);
-    
+
     static const char *strNextArg(const char *&s, const char *pDelim = NULL)
     {   return ls_strnextarg(&s, pDelim);   }
     static char *strNextArg(char *&s, const char *pDelim = NULL)

--- a/src/util/swap.h
+++ b/src/util/swap.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/bsd_nicdetect.cpp
+++ b/src/util/sysinfo/bsd_nicdetect.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/linux_nicdetect.cpp
+++ b/src/util/sysinfo/linux_nicdetect.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/nicdetect.cpp
+++ b/src/util/sysinfo/nicdetect.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/nicdetect.h
+++ b/src/util/sysinfo/nicdetect.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/partitioninfo.cpp
+++ b/src/util/sysinfo/partitioninfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/partitioninfo.h
+++ b/src/util/sysinfo/partitioninfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/siocglif_nicdetect.cpp
+++ b/src/util/sysinfo/siocglif_nicdetect.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/systeminfo.cpp
+++ b/src/util/sysinfo/systeminfo.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/sysinfo/systeminfo.h
+++ b/src/util/sysinfo/systeminfo.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timerprocessor.cpp
+++ b/src/util/timerprocessor.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timerprocessor.h
+++ b/src/util/timerprocessor.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timertask.cpp
+++ b/src/util/timertask.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/timertask.h
+++ b/src/util/timertask.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/tlinklist.cpp
+++ b/src/util/tlinklist.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/tlinklist.h
+++ b/src/util/tlinklist.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/tsingleton.cpp
+++ b/src/util/tsingleton.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/tsingleton.h
+++ b/src/util/tsingleton.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/vmembuf.cpp
+++ b/src/util/vmembuf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/vmembuf.h
+++ b/src/util/vmembuf.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/xmlnode.cpp
+++ b/src/util/xmlnode.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/xmlnode.h
+++ b/src/util/xmlnode.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/src/util/xpool.h
+++ b/src/util/xpool.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/edio/bufferedostest.cpp
+++ b/test/edio/bufferedostest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/edio/bufferedostest.h
+++ b/test/edio/bufferedostest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/edio/multiplexertest.cpp
+++ b/test/edio/multiplexertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/edio/multiplexertest.h
+++ b/test/edio/multiplexertest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/extensions/fcgistartertest.cpp
+++ b/test/extensions/fcgistartertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/chunkistest.cpp
+++ b/test/http/chunkistest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/chunkistest.h
+++ b/test/http/chunkistest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/chunkostest.cpp
+++ b/test/http/chunkostest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/chunkostest.h
+++ b/test/http/chunkostest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/contexttreebench.cpp
+++ b/test/http/contexttreebench.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/contexttreetest.cpp
+++ b/test/http/contexttreetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/contexttreetest.h
+++ b/test/http/contexttreetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/datetimetest.cpp
+++ b/test/http/datetimetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/datetimetest.h
+++ b/test/http/datetimetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/denieddirtest.cpp
+++ b/test/http/denieddirtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/denieddirtest.h
+++ b/test/http/denieddirtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/expirestest.cpp
+++ b/test/http/expirestest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/expirestest.h
+++ b/test/http/expirestest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/fcgistartertest.h
+++ b/test/http/fcgistartertest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpbuftest.cpp
+++ b/test/http/httpbuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpbuftest.h
+++ b/test/http/httpbuftest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpcgitooltest.cpp
+++ b/test/http/httpcgitooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpcgitooltest.h
+++ b/test/http/httpcgitooltest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpheadertest.cpp
+++ b/test/http/httpheadertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpheadertest.h
+++ b/test/http/httpheadertest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpiptogeo2test.cpp
+++ b/test/http/httpiptogeo2test.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httplistenerstest.cpp
+++ b/test/http/httplistenerstest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httplistenerstest.h
+++ b/test/http/httplistenerstest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpmimetest.cpp
+++ b/test/http/httpmimetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpmimetest.h
+++ b/test/http/httpmimetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httprangetest.cpp
+++ b/test/http/httprangetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httprangetest.h
+++ b/test/http/httprangetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpreqheaderstest.cpp
+++ b/test/http/httpreqheaderstest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpreqheaderstest.h
+++ b/test/http/httpreqheaderstest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpreqtest.cpp
+++ b/test/http/httpreqtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpreqtest.h
+++ b/test/http/httpreqtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httprequestlinetest.cpp
+++ b/test/http/httprequestlinetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httprequestlinetest.h
+++ b/test/http/httprequestlinetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpvhostlisttest.cpp
+++ b/test/http/httpvhostlisttest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/httpvhostlisttest.h
+++ b/test/http/httpvhostlisttest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/reqparsertest.cpp
+++ b/test/http/reqparsertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/rewritetest.cpp
+++ b/test/http/rewritetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/rewritetest.h
+++ b/test/http/rewritetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/statusurlmaptest.cpp
+++ b/test/http/statusurlmaptest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/http/statusurlmaptest.h
+++ b/test/http/statusurlmaptest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsiapi/envhandler.cpp
+++ b/test/lsiapi/envhandler.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsiapi/lsiapihookstest.cpp
+++ b/test/lsiapi/lsiapihookstest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsiapi/moduleconf.cpp
+++ b/test/lsiapi/moduleconf.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsiapi/moduledata.cpp
+++ b/test/lsiapi/moduledata.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsiapi/moduletimertest.cpp
+++ b/test/lsiapi/moduletimertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_ahotest.cpp
+++ b/test/lsr/ls_ahotest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_ahotest.h
+++ b/test/lsr/ls_ahotest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_base64test.cpp
+++ b/test/lsr/ls_base64test.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_buftest.cpp
+++ b/test/lsr/ls_buftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -187,7 +187,7 @@ TEST(ls_xbuftest_test)
 #ifdef LSR_BUF_DEBUG
     printf("Start LSR XBuf Test\n");
 #endif
-    
+
     CHECK(0 == ls_xbuf(&buf, 0, pool));
     CHECK(0 == ls_xbuf_size(&buf));
     CHECK(0 == ls_xbuf_capacity(&buf));

--- a/test/lsr/ls_confparsertest.cpp
+++ b/test/lsr/ls_confparsertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_dlinkqtest.cpp
+++ b/test/lsr/ls_dlinkqtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_hashtest.cpp
+++ b/test/lsr/ls_hashtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_lfstacktest.cpp
+++ b/test/lsr/ls_lfstacktest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -225,7 +225,7 @@ static void *benchRun(void *arg)
     {
         pNodes[i] = new StackNode(1);
     }
-    
+
     for (j = 0; j < iLoops; ++j)
     {
         for (i = 0; i < iIterations; ++i)

--- a/test/lsr/ls_linktest.cpp
+++ b/test/lsr/ls_linktest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_locktest.cpp
+++ b/test/lsr/ls_locktest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_loopbuftest.cpp
+++ b/test/lsr/ls_loopbuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_maptest.cpp
+++ b/test/lsr/ls_maptest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_md5test.cpp
+++ b/test/lsr/ls_md5test.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_objarraytest.cpp
+++ b/test/lsr/ls_objarraytest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_objpooltest.cpp
+++ b/test/lsr/ls_objpooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_pcregtest.cpp
+++ b/test/lsr/ls_pcregtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_pooltest.cpp
+++ b/test/lsr/ls_pooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_ptrlisttest.cpp
+++ b/test/lsr/ls_ptrlisttest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_sha1test.cpp
+++ b/test/lsr/ls_sha1test.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_stacktest.cpp
+++ b/test/lsr/ls_stacktest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_strlisttest.cpp
+++ b/test/lsr/ls_strlisttest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_strtest.cpp
+++ b/test/lsr/ls_strtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_strtooltest.cpp
+++ b/test/lsr/ls_strtooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_strtooltest.h
+++ b/test/lsr/ls_strtooltest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_thrsafetest.cpp
+++ b/test/lsr/ls_thrsafetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/ls_xpooltest.cpp
+++ b/test/lsr/ls_xpooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lsr/timer.cpp
+++ b/test/lsr/timer.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lua/lslua.cpp
+++ b/test/lua/lslua.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lua/lsluatty.cpp
+++ b/test/lua/lsluatty.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/lua/luatest.cpp
+++ b/test/lua/luatest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/mthandler/POSTtest.cpp
+++ b/test/mthandler/POSTtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/mthandler/POSTtest2.cpp
+++ b/test/mthandler/POSTtest2.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/lsshmdebug.cpp
+++ b/test/shm/lsshmdebug.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/lsshmdebug.h
+++ b/test/shm/lsshmdebug.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/shmbaselrutest.cpp
+++ b/test/shm/shmbaselrutest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/shmmemcachedtest.cpp
+++ b/test/shm/shmmemcachedtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/shmtest.cpp
+++ b/test/shm/shmtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/shmxtest.cpp
+++ b/test/shm/shmxtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/testshm.cpp
+++ b/test/shm/testshm.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/testshmapi.cpp
+++ b/test/shm/testshmapi.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/testshmhash.cpp
+++ b/test/shm/testshmhash.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/shm/testshmreg.cpp
+++ b/test/shm/testshmreg.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/coresockettest.cpp
+++ b/test/socket/coresockettest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/coresockettest.h
+++ b/test/socket/coresockettest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/hostinfotest.cpp
+++ b/test/socket/hostinfotest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/hostinfotest.h
+++ b/test/socket/hostinfotest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/tcpsockettest.cpp
+++ b/test/socket/tcpsockettest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/socket/tcpsockettest.h
+++ b/test/socket/tcpsockettest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/spdy/dummiostream.cpp
+++ b/test/spdy/dummiostream.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/spdy/dummyiostream.h
+++ b/test/spdy/dummyiostream.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/spdy/pushtest.cpp
+++ b/test/spdy/pushtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/spdy/spdyconnectiontest.cpp
+++ b/test/spdy/spdyconnectiontest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/spdy/spdyzlibfiltertest.cpp
+++ b/test/spdy/spdyzlibfiltertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/thread/mtnotifiertest.cpp
+++ b/test/thread/mtnotifiertest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *
@@ -51,7 +51,7 @@ static void *waitThread(void *arg) {
 
 static void *signalThread(void *arg) {
     MtNotifier *pmtNotifier = (MtNotifier *)arg;
-    
+
     printf("Entered signal thread\n");
     pmtNotifier->notify();
     printf("Called signal, set something and broadcast\n");
@@ -67,13 +67,13 @@ TEST(MTNOTIFIER_BLOCK_RELEASE_TEST)
     pthread_t waitThreadID;
     pthread_t signalThreadID;
     pthread_attr_t pthread_attrWait, pthread_attrSignal;
-    
+
     pthread_attr_init(&pthread_attrWait);
     pthread_attr_init(&pthread_attrSignal);
-    
+
     pthread_create(&waitThreadID, &pthread_attrWait, waitThread, &mtNotifier);
     pthread_create(&signalThreadID, &pthread_attrSignal, signalThread, &mtNotifier);
-    
+
     sleep(1); // Give it a second to finish.
     CHECK(didWait);
     CHECK(didSignal);

--- a/test/thread/pthreadworkqueuetest.cpp
+++ b/test/thread/pthreadworkqueuetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/thread/threadtest.cpp
+++ b/test/thread/threadtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/thread/workcrewtest.cpp
+++ b/test/thread/workcrewtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/unittest_main.cpp
+++ b/test/unittest_main.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/accesscontroltest.cpp
+++ b/test/util/accesscontroltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/accesscontroltest.h
+++ b/test/util/accesscontroltest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/ahotest.cpp
+++ b/test/util/ahotest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/ahotest.h
+++ b/test/util/ahotest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/brotlibuftest.cpp
+++ b/test/util/brotlibuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/dlinkqueuetest.cpp
+++ b/test/util/dlinkqueuetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/dlinkqueuetest.h
+++ b/test/util/dlinkqueuetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/filtermatchtest.cpp
+++ b/test/util/filtermatchtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/filtermatchtest.h
+++ b/test/util/filtermatchtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/ghashtest.cpp
+++ b/test/util/ghashtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/ghashtest.h
+++ b/test/util/ghashtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gmaptest.cpp
+++ b/test/util/gmaptest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gmaptest.h
+++ b/test/util/gmaptest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gpathtest.cpp
+++ b/test/util/gpathtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gpathtest.h
+++ b/test/util/gpathtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gpointerlisttest.cpp
+++ b/test/util/gpointerlisttest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gzipbuftest.cpp
+++ b/test/util/gzipbuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/gzipbuftest.h
+++ b/test/util/gzipbuftest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/httpfetchtest.cpp
+++ b/test/util/httpfetchtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/httpfetchtest.h
+++ b/test/util/httpfetchtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/linkedobjtest.cpp
+++ b/test/util/linkedobjtest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/linkedobjtest.h
+++ b/test/util/linkedobjtest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/logfiletest.cpp
+++ b/test/util/logfiletest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/logfiletest.h
+++ b/test/util/logfiletest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/loopbuftest.cpp
+++ b/test/util/loopbuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/loopbuftest.h
+++ b/test/util/loopbuftest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/objarraytest.cpp
+++ b/test/util/objarraytest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/objpooltest.cpp
+++ b/test/util/objpooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/partitioninfotest.cpp
+++ b/test/util/partitioninfotest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/partitioninfotest.h
+++ b/test/util/partitioninfotest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/pcregextest.cpp
+++ b/test/util/pcregextest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/pcregextest.h
+++ b/test/util/pcregextest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/poolalloctest.cpp
+++ b/test/util/poolalloctest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/poolalloctest.h
+++ b/test/util/poolalloctest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/radixtreetest.cpp
+++ b/test/util/radixtreetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/stringmaptest.cpp
+++ b/test/util/stringmaptest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/stringmaptest.h
+++ b/test/util/stringmaptest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/stringtooltest.cpp
+++ b/test/util/stringtooltest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/stringtooltest.h
+++ b/test/util/stringtooltest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/vmembuftest.cpp
+++ b/test/util/vmembuftest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/vmembuftest.h
+++ b/test/util/vmembuftest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/xmlnodetest.cpp
+++ b/test/util/xmlnodetest.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *

--- a/test/util/xmlnodetest.h
+++ b/test/util/xmlnodetest.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *    Open LiteSpeed is an open source HTTP server.                           *
-*    Copyright (C) 2013 - 2021  LiteSpeed Technologies, Inc.                 *
+*    Copyright (C) 2013 - 2022  LiteSpeed Technologies, Inc.                 *
 *                                                                            *
 *    This program is free software: you can redistribute it and/or modify    *
 *    it under the terms of the GNU General Public License as published by    *


### PR DESCRIPTION
Updated the copyright text to mention the year 2022 in all relevant files. Took care to ensure that the test files that contain '2021' as part of their code string and not the copyright notice are not updated. 
Eg: In `loopbuftest.cpp` the variable `paccept` contains the value `2021222324`. This has not been updated. Only the Copyright notice in the top has been updated for all of the files.

Please let me know if any edits are needed.

Thanks!