### PR TITLE
Extract mid and pid from GET Parameters instead of REQUEST

### DIFF
--- a/dist/admin/html.open/lib/DInfo.php
+++ b/dist/admin/html.open/lib/DInfo.php
@@ -71,11 +71,11 @@ class DInfo
     public function InitConf()
     {
         $has_pid = false;
-        $mid = UIBase::GrabGoodInput("request", 'm');
+        $mid = UIBase::GrabGoodInput("get", 'm');
 
         if ($mid != null) {
             $this->_mid = $mid;
-            $pid = UIBase::GrabGoodInput("request", 'p');
+            $pid = UIBase::GrabGoodInput("get", 'p');
             if ($pid != null) {
                 $this->_pid = $pid;
                 $has_pid = true;

--- a/dist/admin/html.open/lib/DInfo.php
+++ b/dist/admin/html.open/lib/DInfo.php
@@ -71,11 +71,11 @@ class DInfo
     public function InitConf()
     {
         $has_pid = false;
-        $mid = UIBase::GrabGoodInput("get", 'm');
+        $mid = UIBase::GrabGoodInput("get_post", 'm');
 
         if ($mid != null) {
             $this->_mid = $mid;
-            $pid = UIBase::GrabGoodInput("get", 'p');
+            $pid = UIBase::GrabGoodInput("get_post", 'p');
             if ($pid != null) {
                 $this->_pid = $pid;
                 $has_pid = true;

--- a/dist/admin/html.open/view/UIBase.php
+++ b/dist/admin/html.open/view/UIBase.php
@@ -302,6 +302,10 @@ class UIBase
 			break;
 			case "POST": $temp = $_POST;
 			break;
+			case "POST_GET":
+			case "GET_POST":
+				$temp = array_merge($_GET, $_POST);
+				break;
 			case "COOKIE": $temp = $_COOKIE;
 			break;
 			case "FILE": $temp = $_FILES;


### PR DESCRIPTION
Sometimes You will get an Invalid Tab error in the webui, its not possible to access any pages except the Dashboard.

It turned out, that in the cookies there is also an key `m` that will overwrite the `$_GET['m']`.
Because the Tabs should always be send by GET i just replaced the origin of the GrabGoodInput.

https://forum.openlitespeed.org/threads/invalid-tabs-2258.5515/
https://community.cyberpanel.net/t/openlitespeed-invalid-tabs-error/41101