### PR TITLE
Fix lshttpd.service systemd unit

### DIFF
--- a/dist/admin/misc/lshttpd.service.in
+++ b/dist/admin/misc/lshttpd.service.in
@@ -6,12 +6,12 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/openlitespeed.pid
+PIDFile=/run/openlitespeed.pid
 ExecStart=%LSWS_CTRL% start
 ExecReload=%LSWS_CTRL% restart 
 ExecStop=%LSWS_CTRL% delay-stop
 
-KillMode=none
+KillMode=mixed
 PrivateTmp=false
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
> /usr/lib/systemd/system/lshttpd.service:9: PIDFile= references a path below legacy directory /var/run/, updating /var/run/openlitespeed.pid → /run/openlitespeed.pid; please update the unit file accordingly

> /usr/lib/systemd/system/lshttpd.service:14: Unit uses KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update the service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.

Note: nginx is using KillMode=mixed