### PR TITLE
FreeBSD: /dev/shm permanent link

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -514,7 +514,9 @@ fixshmdir()
         mkdir /tmp/shm
         chmod 777  /tmp/shm
         sed -i -e "s/\/dev\/shm/\/tmp\/shm/g" dist/conf/httpd_config.conf.in
-        ln -s /tmp/shm /dev/shm
+        if [ "${OS}" = "FreeBSD" ] ; then
+            echo 'link /tmp/shm shm' >> /etc/devfs.conf
+        fi
     fi
 }
 


### PR DESCRIPTION
This pull request ensures that the symlink for `/dev/shm` on FreeBSD persists across system reboots. By default, creating the symlink with a simple `ln -s /tmp/shm /dev/shm` works temporarily but is removed after a reboot. To make the symlink permanent, this change adds a configuration to FreeBSD’s `devfs.conf`.