### PR TITLE
fix: proxied HEAD response contains content-length

### DIFF
--- a/src/extensions/proxy/proxyconn.cpp
+++ b/src/extensions/proxy/proxyconn.cpp
@@ -690,6 +690,15 @@ int ProxyConn::processResp()
                     setState(PROCESSING);
 
                 setInProcess(0);
+
+                // RFC9110: HEAD requests MAY send Content-Length
+                // This allows Docker registries to work behind litespeed proxy
+                HttpResp *pResp = pHEC->getHttpSession()->getResp();
+                if (pReq->getMethod() == HttpMethod::HTTP_HEAD &&
+                    pReq->getStatusCode() == SC_200) {
+                    pResp->appendContentLenHeader();
+                }
+
                 pHEC->endResponse(0, 0);
                 return 0;
             }


### PR DESCRIPTION
Docker client expects content-length from registries; when proxied through openlitespeed, the content-length header is dropped. This PR sets the header if the request was HEAD and successful.

Fixes #457