### PR TITLE
Login to OLS web admin console using port forwarding

### DIFF
--- a/dist/admin/html.open/lib/LSWebAdmin/Auth/CAuthorizer.php
+++ b/dist/admin/html.open/lib/LSWebAdmin/Auth/CAuthorizer.php
@@ -127,6 +127,14 @@ class CAuthorizer
 
     private function getRequestPort()
     {
+        $host = UIBase::GrabInput('server', 'HTTP_HOST');
+        if ($host !== '' && ($pos = strpos($host, ':')) !== false) {
+            $port = substr($host, $pos + 1);
+            if (ctype_digit($port) && (int) $port > 0 && (int) $port <= 65535) {
+                return (int) $port;
+            }
+        }
+
         $port = UIBase::GrabInput('server', 'SERVER_PORT', 'int');
         return ($port > 0) ? $port : null;
     }


### PR DESCRIPTION
Hardcoded comparison between HTTP_REFERER port and SERVER_PORT breaks admin access when using TCP tunneling solutions like Google Cloud IAP, SSH tunneling, or Docker port mapping where the local port differs from the container/instance port.

The Host header (HTTP_HOST) represents the authority as seen by the client. For CSRF protection, the Referer should match the host the browser is interacting with, not the physical port the server process is bound to.

This change doesn't weaken CSRF protection because it still ensures the Referer matches the actual host/port used to access the application.

https://forum.openlitespeed.org/threads/ols-web-admin-console-login-issue-using-alternative-web-admin-port.14503/

**Note on Reverse Proxies:**

If the web admin console is deployed behind a reverse proxy (e.g., Nginx, HAProxy, Cloudflare), the proxy must be configured to pass the original `Host` header to the backend. If the proxy rewrites the Host header to an internal address or port, the CSRF validation will correctly fail because the external `Referer` will not match the rewritten internal `Host`.