### PR TITLE
Fix Virtual Host config file creation flow

### DIFF
--- a/dist/admin/html.open/lib/LSWebAdmin/Config/Validation/CValidation.php
+++ b/dist/admin/html.open/lib/LSWebAdmin/Config/Validation/CValidation.php
@@ -602,20 +602,37 @@ class CValidation
             $res = $productFilePolicyRes;
         }
 
-		if ($res == -1 && isset($_POST['file_create']) && $_POST['file_create'] == $attr->GetKey() && $this->allow_create($attr, $path)) {
+		$fileCreateTarget = $this->getFileCreateTarget();
+		if ($res == -1 && $fileCreateTarget == $attr->GetKey() && $this->allow_create($attr, $path)) {
 			if (PathTool::createFile($path, $err, $attr->GetKey())) {
+				$message = htmlspecialchars($path, ENT_QUOTES) . ' has been created successfully.';
+				if ($attr->_type != 'filevh') {
+					$message .= ' Click Save to apply this configuration.';
+				}
 				$this->addValidationMessage(
 					'success',
-					htmlspecialchars($path, ENT_QUOTES) . ' has been created successfully. Click Save to apply this configuration.'
+					$message
 				);
 				$err = null;
-				return 0;
+				return ($attr->_type == 'filevh') ? 1 : 0;
 			}
 
 			$res = -1;
 		}
 
 		return $res;
+	}
+
+	protected function getFileCreateTarget()
+	{
+		if ($this->_request != null) {
+			$inputSource = $this->_request->GetInputSource();
+			if ($inputSource != null && $inputSource->HasInput('POST', 'file_create')) {
+				return $inputSource->GrabInput('POST', 'file_create');
+			}
+		}
+
+		return isset($_POST['file_create']) ? trim((string) $_POST['file_create']) : '';
 	}
 
     protected function validateManagedConfigFilePolicy($attr, $path, &$err)


### PR DESCRIPTION
When adding a new Virtual Host through the WebAdmin panel, entering a path for a non-existent config file (for example `$SERVER_ROOT/conf/vhosts/Example2/vhconf.conf`) shows the expected error:

> file /usr/local/lsws/conf/vhosts/Example2/vhconf.conf does not exist.

Clicking the `CLICK TO CREATE` button does create the file on disk, but the Virtual Host itself is never saved. The user has to re-enter everything and click Save again — and many users reported the button feeling completely broken.

Inside `dist/admin/html.open/lib/LSWebAdmin/Config/Validation/CValidation.php`, after the file is created the validator returns `0` (STOP), which tells the save flow to halt:

```php
if (PathTool::createFile($path, $err, $attr->GetKey())) {
    $this->addValidationMessage(
        'success',
        htmlspecialchars($path, ENT_QUOTES) . ' has been created successfully. Click Save to apply this configuration.'
    );
    $err = null;
    return 0; // <-- stops the save, so the new vhost is never persisted
}
```

This was acceptable for things like a missing `userDB` file, but for the Virtual Host registration form it leaves the user with a freshly created empty `vhconf.conf` and no Virtual Host entry in the config — which looks exactly like the button did nothing.

**Fix:**

For the Virtual Host config file (`filevh`), return `1` (OK) after a successful creation so the save flow continues and the Virtual Host is registered in the same submit. Behavior for other file types (templates, user DBs, etc.) is unchanged.

Also resolved POST lookup through the request's input source instead of touching `$_POST` directly, to match the rest of the validator:

```php
$fileCreateTarget = $this->getFileCreateTarget();
if ($res == -1 && $fileCreateTarget == $attr->GetKey() && $this->allow_create($attr, $path)) {
    if (PathTool::createFile($path, $err, $attr->GetKey())) {
        $message = htmlspecialchars($path, ENT_QUOTES) . ' has been created successfully.';
        if ($attr->_type != 'filevh') {
            $message .= ' Click Save to apply this configuration.';
        }
        $this->addValidationMessage('success', $message);
        $err = null;
        return ($attr->_type == 'filevh') ? 1 : 0;
    }
    $res = -1;
}
```

```php
protected function getFileCreateTarget()
{
    if ($this->_request != null) {
        $inputSource = $this->_request->GetInputSource();
        if ($inputSource != null && $inputSource->HasInput('POST', 'file_create')) {
            return $inputSource->GrabInput('POST', 'file_create');
        }
    }

    return isset($_POST['file_create']) ? trim((string) $_POST['file_create']) : '';
}
```


- `CLICK TO CREATE` now creates `vhconf.conf` (and its parent directory) and saves the Virtual Host in a single click.
- The success message no longer asks the user to click Save again for this case.
- No change to template / user DB / group DB creation flows.



