### PR TITLE
Switch to `git clone --depth 1` to save downloaded bytes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -236,7 +236,7 @@ preparelibquic()
         if [ $? -eq 0 ] ; then
             echo Need to git download the submodule ...
             rm -rf lsquic
-            git clone https://github.com/litespeedtech/lsquic.git
+            git clone --depth 1 https://github.com/litespeedtech/lsquic.git
             cd lsquic
             
             LIBQUICVER=`cat ../LSQUICCOMMIT`
@@ -572,7 +572,7 @@ fi
 cd ..
 if [ ! -d third-party ]; then
 
-    git clone https://github.com/litespeedtech/third-party.git
+    git clone --depth 1 https://github.com/litespeedtech/third-party.git
     mkdir third-party/lib64
     cd third-party/script/
 


### PR DESCRIPTION
`lsquic.git` before = 10.54MiB:

```
$ git clone https://github.com/litespeedtech/lsquic.git
Cloning into 'lsquic'...
remote: Enumerating objects: 11183, done.
remote: Counting objects: 100% (3949/3949), done.
remote: Compressing objects: 100% (685/685), done.
remote: Total 11183 (delta 3610), reused 3264 (delta 3264), pack-reused 7234 (from 2)
Receiving objects: 100% (11183/11183), 10.54 MiB | 32.70 MiB/s, done.
Resolving deltas: 100% (8292/8292), done.
```

`lsquic.git` with `--depth 1` = 1.84MiB (download saving of ~82%):

```
$ git clone --depth 1 https://github.com/litespeedtech/lsquic.git
Cloning into 'lsquic'...
remote: Enumerating objects: 338, done.
remote: Counting objects: 100% (338/338), done.
remote: Compressing objects: 100% (325/325), done.
remote: Total 338 (delta 23), reused 71 (delta 10), pack-reused 0 (from 0)
Receiving objects: 100% (338/338), 1.84 MiB | 16.54 MiB/s, done.
Resolving deltas: 100% (23/23), done.
```

`third-party.git` before = 88.57KiB:

```
$ git clone https://github.com/litespeedtech/third-party.git
Cloning into 'third-party'...
remote: Enumerating objects: 671, done.
remote: Counting objects: 100% (122/122), done.
remote: Compressing objects: 100% (79/79), done.
remote: Total 671 (delta 80), reused 68 (delta 43), pack-reused 549 (from 2)
Receiving objects: 100% (671/671), 88.57 KiB | 1.70 MiB/s, done.
Resolving deltas: 100% (396/396), done.
```

`third-party.git` with `--depth 1` = 19.29KiB (download saving of ~78%):

```
$ git clone --depth 1 https://github.com/litespeedtech/third-party.git
Cloning into 'third-party'...
remote: Enumerating objects: 63, done.
remote: Counting objects: 100% (63/63), done.
remote: Compressing objects: 100% (58/58), done.
remote: Total 63 (delta 3), reused 41 (delta 3), pack-reused 0 (from 0)
Receiving objects: 100% (63/63), 19.29 KiB | 3.86 MiB/s, done.
Resolving deltas: 100% (3/3), done.
```