### PR TITLE
Split conf dir/file permission chmod to stop executable-bitting config files

### DIFF
--- a/src/main/httpserver.cpp
+++ b/src/main/httpserver.cpp
@@ -3456,8 +3456,12 @@ void HttpServerImpl::fixConfDirsPermission()
 
     if (needUpdated)
     {
-        ls_snprintf(achBuf, 4096, "chown -R %s:%s %s/conf/; find %s/conf/ -type d -exec chmod -R 0750 {} +",
-                    "lsadm", MainServerConfig::getInstance().getGroup(), pRoot, pRoot);
+        ls_snprintf(achBuf, 4096,
+                    "chown -R %s:%s %s/conf/; "
+                    "find %s/conf/ -type d -exec chmod 0750 {} +; "
+                    "find %s/conf/ -type f -exec chmod 0640 {} +",
+                    "lsadm", MainServerConfig::getInstance().getGroup(), pRoot,
+                    pRoot, pRoot);
         system(achBuf);
     }
 


### PR DESCRIPTION
## Summary

Fixes #493.

`HttpServerImpl::fixConfDirsPermission()` (src/main/httpserver.cpp) rebuilds ownership/permissions under `conf/` on every restart when it detects the tracked test directories (`conf`, `conf/templates`, `conf/vhosts`) are not owned by `lsadm`/configured group or not mode `0750`. The shell command it runs was:

```
chown -R lsadm:<group> <root>/conf/; find <root>/conf/ -type d -exec chmod -R 0750 {} +
```

`find -type d -exec chmod -R 0750 {} +` enumerates every directory and then recursively `chmod -R`s from each one, which stamps mode `0750` onto every regular file underneath as well (`httpd_config.conf`, `mime.properties`, per-vhost `vhconf.conf`, template files, etc). That adds an executable bit to plain configuration files on every server restart, overriding any administrator-set permissions (e.g. `0600` on files with credentials), which is exactly the bug reported in #493.

## Fix

Split the single recursive chmod into two non-recursive `find` passes, matching the reporter's suggested fix:

```
find <root>/conf/ -type d -exec chmod 0750 {} +
find <root>/conf/ -type f -exec chmod 0640 {} +
```

- Directories get `0750` (traversable/writable by owner+group, matches prior intended directory mode).
- Regular files get `0640` (no execute bit), matching the issue's expected behavior.
- The `chown -R lsadm:<group> <root>/conf/` ownership pass is unchanged — this PR only touches the permission bits, not the group/owner logic, so intended `lsadm` ownership is preserved.

## Verification

I do not have a working build environment for the full OpenLiteSpeed toolchain (openssl/pcre/libevent, etc.) available in this environment, so I did **not** compile or run the actual server to test this end-to-end. Instead I verified:

1. **Code review**: read `fixConfDirsPermission()` and the neighboring `testAndFixDirs()` in full to confirm calling conventions (`ls_snprintf` + `system()`), and kept the same style/pattern rather than introducing a new code path.
2. **Standalone shell verification**: reproduced the exact two `find`/`chmod` invocations from the patched format string against a scratch directory tree mimicking `conf/`, `conf/templates/`, `conf/vhosts/<site>/` with mixed file/dir permissions (including a `0600` file to simulate an admin-restricted credential file). Confirmed after running the two commands:
   - all directories end up at `0750`
   - all regular files (including the one manually set to `0600`) end up at `0640`, with **no** execute bit
3. Diffed the change to confirm it's minimal — only the `ls_snprintf` format string/args in `fixConfDirsPermission()`, no other logic touched.

## Test plan

- [x] Manual code review of `fixConfDirsPermission()` and call site
- [x] Shell-level dry run of the two-pass `find`/`chmod` logic against a scratch tree, confirmed expected resulting permissions
- [ ] Full build + live restart test on real OpenLiteSpeed install (not possible in this environment — would appreciate a maintainer or CI smoke test before merge)