### PR TITLE
Dedupe doubled slash in expandVariable

### DIFF
--- a/src/main/configctx.cpp
+++ b/src/main/configctx.cpp
@@ -253,6 +253,7 @@ int ConfigCtx::expandVariable(const char *pValue, char *pBuf,
         {
             const char *pName = NULL;
             int nameLen = -1;
+            int isRootVar = 0;
 
             if (strncasecmp(pBegin + 1, VH_NAME, 7) == 0)
             {
@@ -270,16 +271,19 @@ int ConfigCtx::expandVariable(const char *pValue, char *pBuf,
             {
                 pBegin += 8;
                 pName = s_aVhRoot;
+                isRootVar = 1;
             }
             else if (allVariable && strncasecmp(pBegin + 1, DOC_ROOT, 8) == 0)
             {
                 pBegin += 9;
                 pName = s_aDocRoot;
+                isRootVar = 1;
             }
             else if (allVariable && strncasecmp(pBegin + 1, SERVER_ROOT, 11) == 0)
             {
                 pBegin += 12;
                 pName = MainServerConfig::getInstance().getServerRoot();
+                isRootVar = 1;
             }
             else
             {
@@ -302,6 +306,9 @@ int ConfigCtx::expandVariable(const char *pValue, char *pBuf,
                 memmove(pCur, pName, nameLen);
                 pCur += nameLen;
             }
+
+            if (isRootVar && *pBegin == '/')
+                ++pBegin;
         }
     }
 


### PR DESCRIPTION
Closes #318

## Summary

`ConfigCtx::getRootPath()` already guards against a doubled slash after substituting a root variable (`$SERVER_ROOT`, `$DOC_ROOT`, `$VH_ROOT`):

```cpp
if (ret == 0 && (defRootType != -1) && (*pFile == '/'))
    ++pFile;
```

`ConfigCtx::expandVariable()` performs the same kind of substitution (and is the code path used for arbitrary config values such as external-app `env` entries, e.g. `PHP_INI_SCAN_DIR=$SERVER_ROOT/conf/vhosts/$VH_NAME`, per `extworkerconfig.cpp` and `lsiapilib.cpp`'s `expand_current_server_variable`), but it never had the equivalent guard. Since `MainServerConfig::getServerRoot()` (and the doc-root/vhost-root paths) always end in a trailing `/` (see `LshttpdMain` server-root setup in `lshttpdmain.cpp`), any config value with `$SERVER_ROOT/...`, `$DOC_ROOT/...`, or `$VH_ROOT/...` produced a doubled slash, exactly as reported in #318.

- `$SERVER_ROOT/conf/vhosts/$VH_NAME` → `/usr/local/lsws//conf/vhosts/...` (bug)
- `$SERVER_ROOTconf/vhosts/$VH_NAME` → `/usr/local/lsws/conf/vhosts/...` (workaround shown in the issue)

## Fix

Add the same slash-dedupe guard to `expandVariable()`, applied only for the three root-type variables (mirroring `getRootPath()`'s scope — `$VH_NAME`/`$VH_DOMAIN` are plain string substitutions, not path roots, so they're left untouched):

```cpp
if (isRootVar && *pBegin == '/')
    ++pBegin;
```

Checked all `allVariable=1` call sites (`ConfigCtx::getAbsolute`, `extworkerconfig.cpp`, `lsiapilib.cpp::expand_current_server_variable`) — none rely on a doubled slash; this was consistently a bug, not an intentional case.

## Test plan

This environment has no C/C++ toolchain available for a full OpenLiteSpeed build (`./configure && make`), so I could not run the project's own test suite or a live server. Instead:

- Read through `getRootPath()` and `expandVariable()` and traced how `SERVER_ROOT`/`DOC_ROOT`/`VH_ROOT` are populated (`httpserver.cpp`, `lshttpdmain.cpp`) to confirm they always carry a trailing slash, matching the exact double-slash symptom in the issue.
- Extracted the substitution loop into a standalone `g++`-compiled reproduction (not part of the repo) and confirmed:
  - `$SERVER_ROOT/conf/vhosts/foo` → `/usr/local/lsws/conf/vhosts/foo` (previously would have produced a doubled slash)
  - `$SERVER_ROOTconf/vhosts/foo` → same correct result (matching the issue's stated workaround)
  - `$SERVER_ROOT` alone still resolves with its expected single trailing slash
  - Literal doubled slashes elsewhere in a value (`foo//bar`) are left untouched, since `expandVariable` only rewrites variable substitutions, not arbitrary text

I was unable to run the full OpenLiteSpeed integration/build tests due to lack of a build toolchain in this environment — happy to iterate if CI surfaces anything.