### PR TITLE
Declare lsBindMask in customListen so Node.js apps can start on OLS 1.9.2

### DIFF
--- a/dist/fcgi-bin/lsnode.js
+++ b/dist/fcgi-bin/lsnode.js
@@ -397,6 +397,7 @@ function lsnode_address() {
 
 
 function customListen(port) {
+    var lsBindMask;
     function onListenError(error) {
         restoreBindMask();
         server.emit('error', error);


### PR DESCRIPTION
lsnode.js references `lsBindMask` but never declares it.
So `restoreBindMask()` throws a `ReferenceError`. 
```
sudo -u nobody /usr/bin/node /usr/local/lsws/fcgi-bin/lsnode.js
/usr/local/lsws/fcgi-bin/lsnode.js:409
        if (lsBindMask !== undefined) {
        ^

ReferenceError: lsBindMask is not defined
    at restoreBindMask (/usr/local/lsws/fcgi-bin/lsnode.js:409:9)
    at Server.customListen [as listen] (/usr/local/lsws/fcgi-bin/lsnode.js:458:5)
    at Object.<anonymous> (/usr/local/lsws/Example/html/node/app.js:12:8)
    at Module._compile (node:internal/modules/cjs/loader:1934:14)
    at Object..js (node:internal/modules/cjs/loader:2074:10)
    at Module.load (node:internal/modules/cjs/loader:1656:32)
    at Module._load (node:internal/modules/cjs/loader:1448:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:261:19)
    at Module.require (node:internal/modules/cjs/loader:1679:12)
    at require (node:internal/modules/helpers:196:16)

Node.js v26.7.0
```

Declaring `lsBindMask` eliminates the `ReferenceError` and allows node.js apps to start on OLS 1.9.2