### PR TITLE
Don't force Accept-Encoding: gzip when proxying to backend

### DIFF
--- a/src/extensions/proxy/proxyconn.cpp
+++ b/src/extensions/proxy/proxyconn.cpp
@@ -269,23 +269,17 @@ int ProxyConn::sendReqHeader()
             pReq->dropReqHeader(HttpHeader::H_TRANSFER_ENCODING);
     }
 
-#if 1       //always set "Accept-Encoding" header to "gzip"
+    //Forward the client's own "Accept-Encoding" header to the backend
+    //as-is, so encodings other than gzip (e.g. "br") aren't clobbered.
+    //If the client sent none, add "gzip" so the backend<->OLS leg can
+    //still be compressed; OLS decompresses it before replying to a
+    //client that didn't ask for gzip (see HttpSession::setupGzipFilter).
     char *pAE = (char *)pReq->getHeader(HttpHeader::H_ACC_ENCODING);
-    if (*pAE)
-    {
-        int len = pReq->getHeaderLen(HttpHeader::H_ACC_ENCODING);
-        if (len >= 4)
-        {
-            memmove(pAE, "gzip", 4);
-            memset(pAE + 4, ' ', len - 4);
-        }
-    }
-    else // If accept encoding header does not exist, use predefined.
+    if (!*pAE)
     {
         pExtraHeader = m_extraHeader;
         headerLen += 23;
     }
-#endif
 
     //reconstruct request line if URL has been rewritten
     if (pReq->getRedirects() > 0)


### PR DESCRIPTION
Fixes #265

The proxy code in `proxyconn.cpp` always rewrote the `Accept-Encoding` header to `gzip` before forwarding a request to the backend, no matter what the client actually sent. Anyone whose client asked for `br` (or `gzip, deflate, br`, which is what most browsers send by default) had that silently overwritten, so a brotli-capable backend never got the chance to respond with brotli - the backend always saw `gzip` and OLS ended up serving `Content-Encoding: gzip` regardless of what the client requested.

I checked how the response side handles this before touching anything: `HttpSession::setupGzipFilter` and the CGI/proxy response-header parser only know about `UPSTREAM_GZIP`/`UPSTREAM_DEFLATE` - there's no brotli decoding anywhere on the proxy path (the `BrotliBuf` code that does exist is only used for pre-compressing static files to disk, unrelated). So the fix here is just to stop rewriting a header the client actually sent, and let it pass through unmodified. If the backend responds with `br` because the client asked for `br`, OLS doesn't try to touch a body it doesn't recognize as gzip/deflate-compressed, so it flows straight through to the client that asked for it in the first place.

I left the other half of this alone: when the client sends no `Accept-Encoding` at all, OLS still adds `gzip` for the backend leg (a maintainer commented on the issue that this is intentional, for bandwidth between OLS and the backend, and OLS decompresses it again before replying to a client that never asked for compression).

I don't have a build environment set up for this repo with all the vendored deps (lsquic, boringssl, brotli via the `dl*.sh` scripts), so I wasn't able to do a full compiled test. I did trace through the header-parsing and response-side gzip-filter code by hand to make sure the client's real header ends up untouched and the existing gzip/deflate decompression path is unaffected. Happy to iterate if CI or a maintainer spots something I missed.
