### PR TITLE
Align SHM mmap offsets to the runtime page size

### DIFF
--- a/src/shm/addrmap.cpp
+++ b/src/shm/addrmap.cpp
@@ -189,7 +189,7 @@ int AddrMap::remap(int fd, size_t start_offset, size_t new_size)
 {
     if (mapAddrSpace(new_size) == LS_FAIL)
         return LS_FAIL;
-    start_offset = start_offset & ~(LSSHM_PAGESIZE -1);
+    start_offset = start_offset & ~((size_t)ls_shm_pagesize() - 1);
     while(start_offset < new_size)
     {
         size_t block_end = (start_offset + LARGE_PAGE_SIZE) & ~LARGE_PAGE_MASK;

--- a/src/shm/lsshm.cpp
+++ b/src/shm/lsshm.cpp
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 
 extern "C" {
@@ -76,6 +77,20 @@ int ls_expandfile(int fd, LsShmOffset_t fromsize, LsShmXSize_t incrsize)
     return 0;
 }
 
+
+LsShmSize_t ls_shm_pagesize(void)
+{
+    static LsShmSize_t s_iSysPageSize = 0;
+    if (s_iSysPageSize == 0)
+    {
+        long size = sysconf(_SC_PAGESIZE);
+        if (size < LSSHM_PAGESIZE)
+            size = LSSHM_PAGESIZE;
+        s_iSysPageSize = (LsShmSize_t)size;
+    }
+    return s_iSysPageSize;
+}
+
 };
 
 
@@ -108,7 +123,6 @@ LsShmVersion s_version =
 {
     { LSSHM_VER_MAJOR, LSSHM_VER_MINOR, LSSHM_VER_REL, LSSHM_VER_TYPE }
 };
-LsShmSize_t LsShm::s_iPageSize = LSSHM_PAGESIZE;
 LsShmSize_t LsShm::s_iShmHdrSize = ((sizeof(LsShmMap) + 0xf) &
                                     ~0xf); // align 16
 const char *LsShm::s_pDirBase[] = {NULL, NULL, NULL, NULL, NULL};
@@ -551,8 +565,8 @@ LsShmStatus_t LsShm::openLockShmFile(int mode)
 
 LsShmStatus_t LsShm::newShmMap(LsShmSize_t size, uint64_t id)
 {
-    if (size < s_iPageSize)
-        size = s_iPageSize;
+    if (size < ls_shm_pagesize())
+        size = ls_shm_pagesize();
     if ((expandFile(0, roundToPageSize(size)) != LSSHM_OK)
         || (mapAddrMap(size) != LSSHM_OK))
         return LSSHM_ERROR;
@@ -626,7 +640,7 @@ LsShmStatus_t LsShm::initShm(const char *mapName, LsShmXSize_t size,
         return m_status;
     }
 
-    size = ((size + s_iPageSize - 1) / s_iPageSize) * s_iPageSize;
+    size = roundToPageSize(size);
 
     if (fstat(m_iFd, &mystat) < 0)
     {

--- a/src/shm/lsshm.h
+++ b/src/shm/lsshm.h
@@ -273,7 +273,8 @@ private:
     // only use by physical mapping
     LsShmXSize_t roundToPageSize(LsShmXSize_t size) const
     {
-        return ((size + s_iPageSize - 1) / s_iPageSize) * s_iPageSize;
+        LsShmSize_t pagesize = ls_shm_pagesize();
+        return ((size + pagesize - 1) / pagesize) * pagesize;
     }
 
     LsShmSize_t roundUnitSize(LsShmSize_t pagesize) const
@@ -310,7 +311,6 @@ private:
 
     LsShmLock               m_locks;
     uint32_t                m_iMagic;
-    static LsShmSize_t      s_iPageSize;
     static LsShmSize_t      s_iShmHdrSize;
     static const char      *s_pDirBase[5];
     static int              s_iNumBaseDir;

--- a/src/shm/lsshmtypes.h
+++ b/src/shm/lsshmtypes.h
@@ -108,9 +108,16 @@ typedef v2_comp                 LsShmValComp_fn;
 #define LSSHM_VER_TYPE          \
     (((sizeof(LsShmOffset_t)<<4) | sizeof(LsShmXSize_t)) & (0xff)) // 8 bits
 
-#define LSSHM_PAGESIZE          0x4000  // min pagesize 16k (for 16K-page kernels)
-#define LSSHM_PAGEMASK          0xFFFFC000
+#define LSSHM_PAGESIZE          0x4000  // lower bound only, see ls_shm_pagesize()
 #define LSSHM_MAXNAMELEN        12      // only 11 characters.
+
+/* SHM file offsets end up as the mmap() offset argument, which the kernel
+ * requires to be a multiple of the running system's page size (16K on Apple
+ * Silicon and 16K-page ARM64 kernels, possibly larger on others).  Returns
+ * the larger of sysconf(_SC_PAGESIZE) and LSSHM_PAGESIZE, so the growth
+ * granularity never drops below the historical value either.
+ */
+LsShmSize_t ls_shm_pagesize(void);
 
 #define LSSHM_SYSSHM            "LsShm"     // default SHM name
 #define LSSHM_SYSPOOL           "LsPool"    // default SHM POOL name


### PR DESCRIPTION
Follow-up to the 16K-page crash reported in #486.

The constant bump that landed for that issue (8K -> 16K) fixes Apple Silicon and the 16K-page Pi 5 kernel, but the underlying problem is that `LSSHM_PAGESIZE` is used as the `mmap()` file-offset alignment, and `mmap()` requires that offset to be a multiple of the *running kernel's* page size. Any hardcoded value is going to be wrong on some kernel. 16K is still too small for 64K-page kernels, which are not exotic: RHEL/CentOS/Rocky aarch64 kernels ship with `CONFIG_ARM64_64K_PAGES`, and ppc64le uses 64K pages too. On those, `AddrMap::remap()` can still hand `mmap()` an offset such as 40960, get `EINVAL`, and take the same failing path that ends in the SIGSEGV from the original report.

So rather than pick another number, this adds `ls_shm_pagesize()` in `src/shm/lsshm.cpp`, which returns `max(sysconf(_SC_PAGESIZE), LSSHM_PAGESIZE)`, cached in a static after the first call. The mmap offset alignment in `AddrMap::remap()` and the SHM file growth rounding (`roundToPageSize()`, `newShmMap()`, `initShm()`) now use it. `LSSHM_PAGESIZE` stays in the header as the lower bound, so on 4K and 8K page systems the growth granularity is exactly what it is today and nothing about existing behaviour changes there. The static `LsShm::s_iPageSize`, which existed only to hold that constant, is gone.

Two things I checked before touching anything, since a page-size change sounds riskier than it is:

The on-disk SHM format does not depend on this value. Allocation is in `LSSHM_SHM_UNITSIZE` (1K) units, `x_stat.m_iFileSize` records the real file size, and no header field encodes a page size. Existing `.shm` files created under the old 8K assumption stay readable: `remap()` rounds the start offset *down*, so a file whose size is a multiple of 8K but not of 16K or 64K still gets a valid, page-aligned offset, and the mapping length does not have to be page-aligned (the kernel rounds it up). A larger page size can only ever round further down, never past the start of the containing 1MB `LARGE_PAGE_SIZE` block, so `offset2ptr()` stays consistent.

`LSSHM_PAGESIZE` is not required to be a compile-time constant anywhere that matters. It is not a struct field, array bound, or static initialiser; the only remaining compile-time use is `LSSHM_INITSIZE`, which is itself unused in the tree. `LsShmLock` keeps its own 8K sizing, which is correct as-is because lock files are always mapped from offset 0.

I also removed `LSSHM_PAGEMASK`. It has no references anywhere in the tree and its value hardcodes a page size that is now decided at runtime, so leaving it there seemed like an invitation to reintroduce the bug. Happy to put it back if it is used by anything outside this repository.

What I could and could not verify: the four modified translation units and the rest of `src/shm/` compile cleanly to objects with `g++ -O2 -Wall`. I could not do a full `build.sh` run here, since the environment has no cmake and the lsquic submodule is not checked out, so this has not been linked or run against a live server, and I do not have a 16K or 64K-page machine to reproduce the original crash on. I did verify the alignment arithmetic directly against the offsets from the strace in #486 for page sizes of 4K, 8K, 16K and 64K: every resulting offset is a multiple of the page size and never larger than the input. Testing on Asahi Linux by the original reporter would be worth having before this is merged.

One thing I deliberately left alone: the crash in #486 is really two bugs. The `EINVAL` is the trigger, but the SIGSEGV comes from the teardown path afterwards dereferencing memory that has already been `munmap()`'d (the strace shows the fault address inside the just-unmapped lock map). This PR removes the trigger, not the fragile error path. That second one seems worth a separate look, but I would be guessing without being able to reproduce it.

Closes #486
