### PR TITLE
Make RequestHeader set/unset work on non-indexed request headers (#506)

### DIFF
--- a/src/http/httpreq.cpp
+++ b/src/http/httpreq.cpp
@@ -4060,6 +4060,29 @@ int HttpReq::dropReqHeader(int index)
 }
 
 
+void HttpReq::dropUnknownReqHeader(const char *pName, int nameLen)
+{
+    key_value_pair *pHeader;
+    while ((pHeader = getUnknHeaderByKey(m_headerBuf, pName, nameLen)) != NULL)
+    {
+        if (m_pUpkdHeaders)
+            m_pUpkdHeaders->dropHeader(HttpHeader::H_UNKNOWN, pHeader->valOff);
+        eraseHeader(pHeader);
+        int idx = pHeader - m_unknHeaders.begin();
+        int last = m_unknHeaders.size() - 1;
+        if (idx < last)
+            memmove(pHeader, pHeader + 1,
+                    (last - idx) * sizeof(key_value_pair));
+        m_unknHeaders.pop();
+        //m_iCfRealIpHeader is an one based index into m_unknHeaders
+        if (m_iCfRealIpHeader == idx + 1)
+            m_iCfRealIpHeader = 0;
+        else if (m_iCfRealIpHeader > idx + 1)
+            --m_iCfRealIpHeader;
+    }
+}
+
+
 int HttpReq::applyOp(HttpSession *pSession, const HeaderOp *pOp)
 {
     if (pOp->getOperator() == LSI_HEADER_UNSET)
@@ -4068,6 +4091,8 @@ int HttpReq::applyOp(HttpSession *pSession, const HeaderOp *pOp)
         {
             dropReqHeader(pOp->getIndex());
         }
+        else if (pOp->getIndex() == HttpHeader::H_HEADER_END)
+            dropUnknownReqHeader(pOp->getName(), pOp->getNameLen());
         return 0;
     }
     const char *pValue = pOp->getValue();
@@ -4087,6 +4112,8 @@ int HttpReq::applyOp(HttpSession *pSession, const HeaderOp *pOp)
             updateReqHeader(pOp->getIndex(), pOp->getValue(), pOp->getValueLen());
             break;
         }
+        //not an indexed header, remove the existing one before adding it back
+        dropUnknownReqHeader(pOp->getName(), pOp->getNameLen());
         //fall through
     case LSI_HEADER_ADD:    //add a new line
     case LSI_HEADER_APPEND: //Add with a comma to seperate
@@ -4225,11 +4252,22 @@ void HttpReq::appendReqHeader( const char *pName, int iNameLen,
     if (m_headerBuf.available() < iValLen + iNameLen + 4)
         m_headerBuf.grow(iValLen + iNameLen + 4 - m_headerBuf.available());
 
+    int nameOff = m_headerBuf.size();
     m_headerBuf.append(pName, iNameLen);
     m_headerBuf.append(": ", 2);
+    int valOff = m_headerBuf.size();
     m_headerBuf.append(pValue, iValLen);
     m_headerBuf.append("\r\n\r\n", 4);
     m_iReqHeaderBufFinished = m_iHttpHeaderEnd = m_headerBuf.size();
+
+    if (HttpHeader::getIndex(pName, iNameLen) == HttpHeader::H_HEADER_END)
+    {
+        key_value_pair *pIdx = newUnknownHeader();
+        pIdx->keyOff = nameOff;
+        pIdx->keyLen = iNameLen;
+        pIdx->valOff = valOff;
+        pIdx->valLen = iValLen;
+    }
 }
 
 

--- a/src/http/httpreq.h
+++ b/src/http/httpreq.h
@@ -921,6 +921,7 @@ public:
     int createHeaderValue(HttpSession *pSession, const char *pFmt, int len,
                           char *pBuf, int maxLen);
     void eraseHeader(key_value_pair * pHeader);
+    void dropUnknownReqHeader(const char *pName, int nameLen);
 
     void appendReqHeader( const char *pName, int iNameLen,
                           const char *pValue, int iValLen);

--- a/test/http/httpreqtest.cpp
+++ b/test/http/httpreqtest.cpp
@@ -436,6 +436,60 @@ SUITE(HttpReqTest)
 
         delete []pURI;
     }
+
+    static int countHeaderName(HttpReq &req, const char *pName, int nameLen)
+    {
+        const char *p = req.getOrgReqLine();
+        const char *pEnd = p + req.getHttpHeaderLen();
+        int count = 0;
+        while ((p = (const char *)memchr(p, '\n', pEnd - p)) != NULL)
+        {
+            ++p;
+            if (pEnd - p > nameLen && *(p + nameLen) == ':'
+                && strncasecmp(p, pName, nameLen) == 0)
+                ++count;
+        }
+        return count;
+    }
+
+    TEST(HttpReqTest_setUnsetUnknownReqHeader)
+    {
+        const char *pInput =
+            "GET /api/ HTTP/1.1\r\n"
+            "Host: www.example.com\r\n"
+            "Origin: https://client.example\r\n"
+            "Connection: close\r\n"
+            "\r\n";
+        HttpReqTst req;
+        req.appendLogId("setUnsetUnknownReqHeader");
+        req.reset(0);
+        req.setVHost((HttpVHost *)1);
+        CHECK(0 == req.append(pInput, strlen(pInput)));
+        CHECK(1 == countHeaderName(req, "Origin", 6));
+
+        HttpHeaderOps ops;
+        const char *pVal = "https://proxy.example";
+        HeaderOp *pSet = ops.append(HttpHeader::getIndex("Origin", 6),
+                                    "Origin", 6, pVal, strlen(pVal),
+                                    LSI_HEADER_SET, 1);
+        req.applyOp(NULL, pSet);
+        //"set" must replace the client's header, not add a second one
+        CHECK(1 == countHeaderName(req, "Origin", 6));
+        req.applyOp(NULL, pSet);
+        CHECK(1 == countHeaderName(req, "Origin", 6));
+        int valLen = 0;
+        const char *pParsed = req.getHeader("origin", 6, valLen);
+        CHECK(NULL != pParsed);
+        CHECK(valLen == (int)strlen(pVal));
+        CHECK(0 == strncmp(pParsed, pVal, valLen));
+
+        HeaderOp *pUnset = ops.append(HttpHeader::getIndex("Origin", 6),
+                                      "Origin", 6, "", 0,
+                                      LSI_HEADER_UNSET, 1);
+        req.applyOp(NULL, pUnset);
+        CHECK(0 == countHeaderName(req, "Origin", 6));
+        CHECK(NULL == req.getHeader("origin", 6, valLen));
+    }
 }
 
 


### PR DESCRIPTION
`RequestHeader set` and `RequestHeader unset` only work on request headers that have a built-in index (Host, Content-Type, Cookie and friends). For anything else, including Origin, `set` falls through to the `add` case in `HttpReq::applyOp()` and appends another header line, and `unset` returns without doing anything because `dropReqHeader()` only knows about indexed headers. That is why the reporter in #506 got *more* duplicate Origin headers after adding `RequestHeader unset Origin` followed by `RequestHeader set Origin ...`, and why a duplicate cannot be collapsed from the config at all. The proxy handler forwards the request header buffer verbatim, so once a duplicate line is in that buffer the backend sees it.

Two changes. `appendReqHeader()` now records a header it appends in the unknown-header index when the name has no built-in index, so it can be found again afterwards. `applyOp()` drops any existing header of the same name before `set` appends it, and on `unset`, through a new `dropUnknownReqHeader()` that erases the line with the existing `eraseHeader()` helper and removes the index entry, adjusting `m_iCfRealIpHeader` since that is a one-based index into the same array.

A side effect worth noting: with `set` replacing rather than appending, applying the same op more than once is now idempotent. Vhost-level ops are applied once directly and again as inherited entries when the context ops run, and `HT_PROXY` applies header ops on its own path, so a `set` op could previously add a copy per application.

I added `HttpReqTest_setUnsetUnknownReqHeader` in `test/http/httpreqtest.cpp`: it parses a request carrying one Origin, applies `set` twice and expects exactly one Origin with the new value, then applies `unset` and expects the header to be gone from both the buffer and `getHeader()`. I could only syntax-check `src/http/httpreq.cpp` and the test file with `g++ -fsyntax-only` here — I do not have a full build of this project available, so I have not been able to run the test itself.

One thing I want to flag honestly: I diffed v1.9.0..v1.9.1 and could not find a change that makes the server add an Origin header, and nothing in the tree adds one. The forwarded buffer only gains a header line through `appendReqHeader()`, so the extra Origin in that report has to originate from a header op somewhere in the configuration. This fix makes those ops behave as configured and makes the reporter's workaround work, but if there really is no Origin op anywhere in their config then something else is also in play, and the full vhost config would help to chase that down.

Closes #506
