### PR TITLE
Reject NUL bytes in request URIs with 400 (#434)

### DIFF
--- a/src/http/httpreq.cpp
+++ b/src/http/httpreq.cpp
@@ -772,6 +772,11 @@ int HttpReq::parseURI(const char *pCur, const char *pBEnd)
     char *p = (char *)ls_xpool_alloc(m_pPool, len + URL_INDEX_PAD);
     int n = HttpUtil::unescape(p, len, pCur);
     --n;
+    if (memchr(p, 0, n))
+    {
+        LS_INFO(getLogSession(), "Status 400: NUL byte in request URI!");
+        return SC_400;
+    }
     n = GPath::clean(p, n);
     if (n <= 0)
         return SC_400;

--- a/test/http/httpreqtest.cpp
+++ b/test/http/httpreqtest.cpp
@@ -335,6 +335,52 @@ SUITE(HttpReqTest)
         CHECK(ret == SC_400);
     }
 
+    TEST(HttpReqTest_rejectNulByteInURI)
+    {
+        const char pInput[] =
+        {
+            "GET /a\0b HTTP/1.1\r\n"
+            "Host: www.example.com\r\n"
+            "\r\n"
+        };
+        HttpReqTst req;
+        req.appendLogId("rejectNulByteInURI");
+        req.reset(0);
+        req.setVHost((HttpVHost *)1);
+
+        int len = sizeof(pInput) - 1;
+        int ret = 1;
+        for (int i = 0; i < len; ++i)
+        {
+            ret = req.append(pInput + i, 1);
+            if (ret == SC_400)
+                break;
+        }
+        CHECK(ret == SC_400);
+    }
+
+    TEST(HttpReqTest_rejectPercentEncodedNulByteInURI)
+    {
+        const char *pInput =
+            "GET /a%00b HTTP/1.1\r\n"
+            "Host: www.example.com\r\n"
+            "\r\n";
+        HttpReqTst req;
+        req.appendLogId("rejectPercentEncodedNulByteInURI");
+        req.reset(0);
+        req.setVHost((HttpVHost *)1);
+
+        int len = strlen(pInput);
+        int ret = 1;
+        for (int i = 0; i < len; ++i)
+        {
+            ret = req.append(pInput + i, 1);
+            if (ret == SC_400)
+                break;
+        }
+        CHECK(ret == SC_400);
+    }
+
     TEST(HttpReqTest_testParseWhitespaceCookie)
     {
         const char pInput[] =


### PR DESCRIPTION
`HttpReq::parseURI()` decodes the request-target with `HttpUtil::unescape()`, which is length-bound and copies an embedded NUL byte through like any other byte, then hands the result to `GPath::clean()`. `clean()` takes an explicit length but its main scan loop is `while ((ch = *p0++))`, so it stops at the first NUL regardless of the length it was given and returns a truncated length. That's the origin-server truncation from the issue. The reverse-proxy path forwards the original request line by byte length, not the decoded/cleaned URI, so a NUL in the URI reaches the proxied backend unmodified either way - same root cause covers both cases in the issue.

Fix adds a length-bound `memchr` check between `unescape()` and `clean()` and returns 400 if it finds one, so `clean()` never sees a NUL to truncate at, and the request never reaches the proxy path either. Same pattern the code already uses for NUL bytes inside header values a few hundred lines down in the same file (`processHeaderLines()`), just missing for the URI itself.

Added two tests in `test/http/httpreqtest.cpp`: one with a literal NUL in the URI, one with `%00`. Both feed the request byte-by-byte through the real parser and expect 400.

I don't have the third-party toolchain (pcre2/openssl/lsquic build, etc.) available here to build and run `ols_unittest`, so I couldn't run these through the actual suite. What I did instead: copied `unescape()` and `clean()` verbatim into a standalone file and ran both a literal-NUL and a `%00` URI through the real before/after logic outside the project build - before the fix both truncate to `/a` silently, after the fix both return 400, and a normal `/a/../b` with no NUL cleans to `/b` identically before and after (no regression to the existing path-cleaning behavior). Happy to share that scratch file if useful, and would appreciate someone running the actual suite before merge.

Fixes #434
