### PR TITLE
Point systemd unit's PIDFile at the actual default pid path (#443)

### DIFF
--- a/dist/admin/misc/lshttpd.service.in
+++ b/dist/admin/misc/lshttpd.service.in
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/openlitespeed.pid
+PIDFile=/tmp/lshttpd/lshttpd.pid
 ExecStart=%LSWS_CTRL% start
 ExecReload=%LSWS_CTRL% restart 
 ExecStop=%LSWS_CTRL% delay-stop


### PR DESCRIPTION
`lshttpd.service.in` declares `PIDFile=/var/run/openlitespeed.pid`, but the server's own compiled default (`PID_FILE` in `src/config.h.cmake`) is `/tmp/lshttpd/lshttpd.pid` - the same path `lswsctrl` itself falls back to when `$PIDFILE` isn't set. Under `Type=forking`, systemd reads `PIDFile` after the daemon forks to learn the real PID. Pointed at a path the daemon never writes to, systemd's own idea of the running PID never matches reality - `lswsctrl` works fine called directly since it already uses the right default, but restart/reload/status routed through systemd is left tracking the wrong (or no) PID, which is exactly the "calling lswsctrl for restart fails to find correct service pid" symptom in the issue.

Fix is a one-line change to match the compiled default. Confirmed there's no other systemd unit file or install-time substitution for this value (only `%LSWS_CTRL%` gets templated via `sed` at install time, in `dist/functions.sh`), and `PrivateTmp=false` is already set so systemd can see `/tmp/lshttpd/` unnamespaced.

Fixes #443
