### PR TITLE
Fix HTTP/3 requests logging as HTTP/1.x in access log

### DIFF
--- a/src/http/httpsession.cpp
+++ b/src/http/httpsession.cpp
@@ -240,6 +240,9 @@ int HttpSession::onInitConnected()
     const ConnInfo *pInfo = getStream()->getConnInfo();
     m_lReqTime = DateTime::s_curTime;
     m_iReqTimeUs = DateTime::s_curTimeUs;
+    m_iFlag = 0;
+    m_iFlag2 = 0;
+    ls_atomic_setint(&m_iMtFlag, 0);
 
     if (pInfo->m_pCrypto)
     {
@@ -260,9 +263,6 @@ int HttpSession::onInitConnected()
     //assert(pInfo->m_pClientInfo);
     setClientInfo(pInfo->m_pClientInfo);
     m_iRemotePort = pInfo->m_remotePort;
-    m_iFlag = 0;
-    m_iFlag2 = 0;
-    ls_atomic_setint(&m_iMtFlag, 0);
 
     m_curHookLevel = 0;
     setLogger(getStream()->getLogger());


### PR DESCRIPTION
The HSF2_IS_HTTP3 flag is set in `onInitConnected()` when a connection is HTTP/3, but the same function unconditionally zeroes `m_iFlag2` a few lines later, wiping it out before anything ever reads it. `isHttp3()` can never return true as a result, which is why `fixHttpVer()` in accesslog.cpp never rewrites the logged version for HTTP/3 requests — they stay logged as HTTP/1.x even though 1.8.3 added the code path to log them correctly.

HTTP/2's equivalent flag doesn't have this problem because it gets set later in the request lifecycle, after this reset.

Fix moves the flag reset earlier, before the block that sets HSF2_IS_HTTP3, instead of after it. Nothing between the new and old position of the reset touches m_iFlag/m_iFlag2, so this doesn't change anything else.

Fixes #514
