### PR TITLE
Fix stale file ownership in stat dir after user/group change (#319)

### DIFF
--- a/src/main/httpserver.cpp
+++ b/src/main/httpserver.cpp
@@ -3851,6 +3851,20 @@ void HttpServerImpl::verifyStatDir(const char *path)
                 if (rootuser)
                 {
                     chown(path, pw->pw_uid, pw->pw_gid);
+                    DIR *dir = opendir(path);
+                    if (dir)
+                    {
+                        struct dirent *entry;
+                        while ((entry = readdir(dir)) != NULL)
+                        {
+                            if (strcmp(entry->d_name, ".") != 0
+                                && strcmp(entry->d_name, "..") != 0)
+                                fchownat(dirfd(dir), entry->d_name,
+                                         pw->pw_uid, pw->pw_gid,
+                                         AT_SYMLINK_NOFOLLOW);
+                        }
+                        closedir(dir);
+                    }
                     error = 0;
                 }
                 else


### PR DESCRIPTION
When the stat directory (default `/tmp/lshttpd/`) already exists on reinstall and the configured run user/group changes, `verifyStatDir()` chowns the directory itself but never touches the files already inside it (`.rtreport`, `.status`, socket/pid files). The worker then runs as the new user and can't write to those files, which is exactly the "Failed to open the real time report" error in the issue.

Fixed by chowning the direct children of the stat directory alongside the directory itself, in the same root-owned branch that already exists in `verifyStatDir()` (src/main/httpserver.cpp). Only touches direct children (`swap/` is already handled separately), uses `fchownat` with `AT_SYMLINK_NOFOLLOW` so a symlink inside the directory can't be used to chown something outside it.

No existing test harness fits this (needs real root + two different uids), so I've verified manually: create the stat dir with children owned by user A, reconfigure to run as user B, restart as root, confirm the directory and its direct children are now owned by B (`find /path/to/statdir -maxdepth 1 -printf '%u:%g %f\n'`), including that a planted symlink's target ownership is untouched. Also confirmed the touched file compiles cleanly (syntax-check with the project's CMake include paths/defines).

Closes #319