### PR TITLE
Reject missing vhost root directory in WebAdmin (#398)

### DIFF
--- a/dist/admin/html.open/lib/LSWebAdmin/Config/Validation/CValidation.php
+++ b/dist/admin/html.open/lib/LSWebAdmin/Config/Validation/CValidation.php
@@ -839,16 +839,16 @@ class CValidation
 			return -1;
 		}
 
-		$s = substr($path, 0, 1);
-
-		if (strpos($path, '$VH_NAME') !== false) {
+		if (stripos($path, '$VH_NAME') !== false) {
 			$viewName = ($this->_request == null) ? null : $this->_request->GetViewName();
 			if ($viewName == null) {
 				$err = 'Fail to find $VH_NAME';
 				return -1;
 			}
-			$path = str_replace('$VH_NAME', $viewName, $path);
+			$path = str_ireplace('$VH_NAME', $viewName, $path);
 		}
+
+		$s = substr($path, 0, 1);
 
 		if ($s == '/') {
 			return 1;

--- a/dist/admin/html.open/lib/LSWebAdmin/Product/WebServer/DTblDefBase.php
+++ b/dist/admin/html.open/lib/LSWebAdmin/Product/WebServer/DTblDefBase.php
@@ -611,7 +611,7 @@ class DTblDefBase extends ProductDTblDefBase
 	{
 		$attrs = [
 			self::NewTextAttr('name', DMsg::ALbl('l_vhname'), 'vhname', false, 'vhName'),
-			self::NewTextAttr('vhRoot', DMsg::ALbl('l_vhroot'), 'cust', false), // do not check path for vhroot, it may be different owner
+			self::NewPathAttr('vhRoot', DMsg::ALbl('l_vhroot'), 'path', 2, 'x', false),
 			self::NewPathAttr('configFile', DMsg::ALbl('l_configfile'), 'filevh', 3, 'rwc', false),
 			$this->_attrs['note']
 		];

--- a/dist/admin/html.open/lib/LSWebAdmin/Product/WebServer/Ols/DTblDefBase.php
+++ b/dist/admin/html.open/lib/LSWebAdmin/Product/WebServer/Ols/DTblDefBase.php
@@ -860,7 +860,7 @@ class DTblDefBase extends ProductDTblDefBase
 	{
 		$attrs = [
 			self::NewTextAttr('name', DMsg::ALbl('l_vhname'), 'vhname', false, 'vhName'),
-			self::NewTextAttr('vhRoot', DMsg::ALbl('l_vhroot'), 'cust', false), //no validation, maybe suexec owner
+			self::NewPathAttr('vhRoot', DMsg::ALbl('l_vhroot'), 'path', 2, 'x', false),
 			self::NewPathAttr('configFile', DMsg::ALbl('l_configfile'), 'filevh', 3, 'rwc', false),
 			$this->_attrs['note'],
 			$this->_attrs['vh_allowSymbolLink'],


### PR DESCRIPTION
Adding a vhost with a `vhRoot` that doesn't exist yet used to save silently — the server then just 404s requests for that vhost with only a generic WARN in error.log, which is what made this so hard to debug in the issue.

Traced it end to end: `getValidPath()` in configctx.cpp already logs the missing path at startup, but WebAdmin's vhost form intentionally skips path validation for `vhRoot` (marked as `'cust'` with comments like "do not check path for vhroot, it may be different owner" — presumably for suexec setups where the webadmin process can't read/write the vhost's actual directory). So the real gap isn't log severity, it's that WebAdmin lets you save a config pointing at a directory that isn't there at all.

Switched `vhRoot` to `NewPathAttr(..., 'x', ...)` so WebAdmin now requires the directory to exist before saving, with a clear inline error (and a "click to create" button where that's allowed) — same UX already used for `configFile`. Kept the `'x'` flag rather than `'r'`/`'w'` so this only checks existence, not readability/writability, which preserves the original suexec-ownership case the old comment was protecting.

While in there, fixed `get_abs_path()` computing whether a `$VH_NAME`-templated path is absolute using the un-substituted path (so a leading `$VH_NAME` token that expands to an absolute path was being misclassified) — this only became reachable now that vhRoot actually goes through validation. Also made the `$VH_NAME` token match case-insensitively for consistency with how it's substituted elsewhere.

Verified with a set of validator probes (existing dir accepted, missing dir rejected, ordinary file rejected, `$SERVER_ROOT/$VH_NAME` and case variants accepted) and PHP syntax checks on all three touched files. No C++ was touched, so no server rebuild needed.

Closes #398